### PR TITLE
fix(ci): make deploy smoke checks work with internal ALB endpoints

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -272,6 +272,7 @@ jobs:
           API_BASE_URL: ${{ steps.terraform_deploy.outputs.api_base_url }}
           ECS_CLUSTER_NAME: ${{ steps.terraform_deploy.outputs.ecs_cluster_name }}
           ECS_API_SERVICE_NAME: ${{ steps.terraform_deploy.outputs.ecs_api_service_name }}
+          ALB_INTERNAL: ${{ steps.terraform_deploy.outputs.alb_internal }}
           AWS_REGION: ${{ env.AWS_REGION }}
           SMOKE_MAX_ATTEMPTS: "30"
           SMOKE_SLEEP_SECONDS: "5"
@@ -386,6 +387,7 @@ jobs:
           API_BASE_URL: ${{ steps.terraform_deploy.outputs.api_base_url }}
           ECS_CLUSTER_NAME: ${{ steps.terraform_deploy.outputs.ecs_cluster_name }}
           ECS_API_SERVICE_NAME: ${{ steps.terraform_deploy.outputs.ecs_api_service_name }}
+          ALB_INTERNAL: ${{ steps.terraform_deploy.outputs.alb_internal }}
           AWS_REGION: ${{ env.AWS_REGION }}
           SMOKE_MAX_ATTEMPTS: "40"
           SMOKE_SLEEP_SECONDS: "5"
@@ -500,6 +502,7 @@ jobs:
           API_BASE_URL: ${{ steps.terraform_deploy.outputs.api_base_url }}
           ECS_CLUSTER_NAME: ${{ steps.terraform_deploy.outputs.ecs_cluster_name }}
           ECS_API_SERVICE_NAME: ${{ steps.terraform_deploy.outputs.ecs_api_service_name }}
+          ALB_INTERNAL: ${{ steps.terraform_deploy.outputs.alb_internal }}
           AWS_REGION: ${{ env.AWS_REGION }}
           SMOKE_MAX_ATTEMPTS: "40"
           SMOKE_SLEEP_SECONDS: "5"

--- a/infra/terraform/control-plane/outputs.tf
+++ b/infra/terraform/control-plane/outputs.tf
@@ -43,6 +43,11 @@ output "api_base_url" {
   description = "SparkPilot API base URL. Uses https:// when acm_certificate_arn is set, http:// otherwise."
 }
 
+output "alb_internal" {
+  value       = local.alb_internal
+  description = "Whether the API ALB is internal-only."
+}
+
 output "https_enabled" {
   value       = local.https_enabled
   description = "Whether HTTPS is enabled on the API ALB."

--- a/scripts/smoke/control_plane_api.sh
+++ b/scripts/smoke/control_plane_api.sh
@@ -28,12 +28,24 @@ max_attempts="${SMOKE_MAX_ATTEMPTS:-30}"
 sleep_seconds="${SMOKE_SLEEP_SECONDS:-5}"
 api_host="${api_base_url#*://}"
 api_host="${api_host%%/*}"
+alb_internal_raw="${ALB_INTERNAL:-}"
+alb_internal_normalized="$(echo "${alb_internal_raw}" | tr '[:upper:]' '[:lower:]')"
+is_internal_alb="false"
+
+if [[ "${alb_internal_normalized}" == "true" ]]; then
+  is_internal_alb="true"
+elif [[ "${alb_internal_normalized}" == "false" ]]; then
+  is_internal_alb="false"
+elif [[ "${api_host}" == internal-* ]]; then
+  # Backward compatibility if ALB_INTERNAL was not exported yet.
+  is_internal_alb="true"
+fi
 
 echo "Running control-plane smoke checks against ${api_base_url}"
 
 # GitHub-hosted runners cannot reach private/internal ALBs directly.
 # For internal endpoints, validate ECS service health via the ECS API instead.
-if [[ "${api_host}" == internal-* ]]; then
+if [[ "${is_internal_alb}" == "true" ]]; then
   require_env "ECS_CLUSTER_NAME"
   require_env "ECS_API_SERVICE_NAME"
   require_env "AWS_REGION"
@@ -43,7 +55,7 @@ if [[ "${api_host}" == internal-* ]]; then
     exit 1
   fi
 
-  echo "::notice::Detected internal endpoint (${api_host}); using ECS service health checks instead of direct HTTP."
+  echo "::notice::Detected internal ALB endpoint (${api_host}); using ECS service health checks instead of direct HTTP."
 
   attempt=1
   last_service_payload=""
@@ -94,6 +106,8 @@ if [[ "${api_host}" == internal-* ]]; then
     attempt=$((attempt + 1))
   done
 fi
+
+echo "::notice::Endpoint (${api_host}) is external; proceeding with HTTP health checks."
 
 attempt=1
 last_payload=""

--- a/scripts/terraform/deploy_control_plane.sh
+++ b/scripts/terraform/deploy_control_plane.sh
@@ -219,6 +219,11 @@ bootstrap_secret_arn="$(terraform -chdir="${terraform_root}" output -raw bootstr
 ecs_cluster_name="$(terraform -chdir="${terraform_root}" output -raw ecs_cluster_name 2>/dev/null || true)"
 ecs_worker_service_names_json="$(terraform -chdir="${terraform_root}" output -json ecs_worker_service_names 2>/dev/null || echo '{}')"
 ecs_api_service_name="$(terraform -chdir="${terraform_root}" output -raw ecs_api_service_name 2>/dev/null || true)"
+alb_internal="$(terraform -chdir="${terraform_root}" output -raw alb_internal 2>/dev/null || echo "false")"
+
+if [[ -z "${alb_internal}" ]]; then
+  alb_internal="false"
+fi
 
 if [[ -z "${database_url_secret_arn}" ]]; then
   echo "::error::Terraform output 'database_url_secret_arn' is empty." >&2
@@ -296,4 +301,5 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "api_base_url=${api_base_url}" >> "${GITHUB_OUTPUT}"
   echo "ecs_cluster_name=${ecs_cluster_name}" >> "${GITHUB_OUTPUT}"
   echo "ecs_api_service_name=${ecs_api_service_name}" >> "${GITHUB_OUTPUT}"
+  echo "alb_internal=${alb_internal}" >> "${GITHUB_OUTPUT}"
 fi


### PR DESCRIPTION
## Problem
Main deploy run now reaches Terraform apply, but deploy-dev fails at smoke check because CI curls an internal ALB URL from a GitHub-hosted runner.

Evidence:
- Failed run: https://github.com/JoshMcQ/SparkPilot/actions/runs/23770421874
- Failed step: Smoke check deployed API (dev)
- Log shows endpoint: http://internal-sparkpilot-dev-alb-...elb.amazonaws.com
- Repeated timeout: curl: (28) Connection timed out after 10002 milliseconds

## Changes
1. Exported ECS identifiers from deploy script outputs:
   - ecs_cluster_name
   - ecs_api_service_name
2. Updated smoke workflow env (dev/staging/prod) to pass ECS identifiers and AWS_REGION into smoke script.
3. Updated scripts/smoke/control_plane_api.sh:
   - Detects internal endpoint hosts (internal-*).
   - Uses ws ecs describe-services readiness checks for private endpoints.
   - Keeps existing HTTP /healthz + unauthenticated 401 probe for public endpoints.

## Why this is correct
- CI runners cannot directly reach private/internal ALBs.
- ECS API-based readiness is reachable from CI via assumed AWS role.
- Public endpoint deployments still get direct HTTP + auth sanity checks.

## Verification
- Main failure reproduced and tied to internal ALB smoke timeout in run logs.
- Script/workflow path updated to branch by endpoint accessibility.

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced smoke testing to verify internal service health via ECS monitoring alongside existing HTTP checks.
  * Updated CI/CD pipeline to provide necessary configuration for comprehensive health verification during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->