### PR TITLE
fix(deploy): restore ECS startup in private subnets via Secrets Manager VPCE

### DIFF
--- a/infra/terraform/control-plane/main.tf
+++ b/infra/terraform/control-plane/main.tf
@@ -347,6 +347,39 @@ resource "aws_vpc_security_group_egress_rule" "ecs_tasks_all" {
   description       = "Allow all ECS task egress"
 }
 
+resource "aws_security_group" "aws_api_endpoints" {
+  name        = "${local.name_prefix}-aws-api-endpoints"
+  description = "Security group for private AWS API interface endpoints"
+  vpc_id      = var.vpc_id
+  tags        = local.tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "aws_api_endpoints_https_from_ecs" {
+  security_group_id            = aws_security_group.aws_api_endpoints.id
+  referenced_security_group_id = aws_security_group.ecs_tasks.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  description                  = "Allow HTTPS from ECS tasks to interface endpoints"
+}
+
+resource "aws_vpc_security_group_egress_rule" "aws_api_endpoints_all" {
+  security_group_id = aws_security_group.aws_api_endpoints.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Allow endpoint egress"
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = [aws_security_group.aws_api_endpoints.id]
+  tags                = local.tags
+}
+
 resource "aws_security_group" "postgres" {
   name        = "${local.name_prefix}-postgres"
   description = "SparkPilot postgres security group"

--- a/scripts/smoke/control_plane_api.sh
+++ b/scripts/smoke/control_plane_api.sh
@@ -76,16 +76,16 @@ if [[ "${is_internal_alb}" == "true" ]]; then
         desired_count="$(echo "${service_payload}" | jq -r '.services[0].desiredCount // 0')"
         running_count="$(echo "${service_payload}" | jq -r '.services[0].runningCount // 0')"
         pending_count="$(echo "${service_payload}" | jq -r '.services[0].pendingCount // 0')"
-        failed_rollouts="$(echo "${service_payload}" | jq -r '[.services[0].deployments[]? | select(.rolloutState == "FAILED")] | length')"
+        primary_rollout_state="$(echo "${service_payload}" | jq -r '([.services[0].deployments[]? | select(.status == "PRIMARY")][0].rolloutState) // ""')"
 
-        if [[ "${service_status}" == "ACTIVE" && "${desired_count}" -gt 0 && "${running_count}" -ge "${desired_count}" && "${pending_count}" -eq 0 && "${failed_rollouts}" -eq 0 ]]; then
+        if [[ "${service_status}" == "ACTIVE" && "${desired_count}" -gt 0 && "${running_count}" -ge "${desired_count}" && "${pending_count}" -eq 0 && "${primary_rollout_state}" != "FAILED" ]]; then
           echo "ECS service health check passed on attempt ${attempt}/${max_attempts}."
           echo "Skipping unauthenticated HTTP probe for internal endpoint."
           echo "Smoke checks passed."
           exit 0
         fi
 
-        echo "ECS service not ready (attempt ${attempt}/${max_attempts}): status=${service_status}, desired=${desired_count}, running=${running_count}, pending=${pending_count}, failed_rollouts=${failed_rollouts}"
+        echo "ECS service not ready (attempt ${attempt}/${max_attempts}): status=${service_status}, desired=${desired_count}, running=${running_count}, pending=${pending_count}, primary_rollout_state=${primary_rollout_state}"
       else
         echo "ECS service lookup returned no services (attempt ${attempt}/${max_attempts})."
       fi


### PR DESCRIPTION
## Problem
After fixing CI smoke pathing, main deploy still fails in deploy-dev because ECS tasks cannot reach Secrets Manager from private subnets.

Evidence:
- Run: https://github.com/JoshMcQ/SparkPilot/actions/runs/23771437387
- Job: deploy-dev
- Step: Smoke check deployed API (dev)
- ECS event in logs: ResourceInitializationError ... unable to retrieve secret from asm ... connection issue between the task and AWS Secrets Manager

## Changes
1. Added private interface endpoint connectivity for Secrets Manager in control-plane Terraform:
   - ws_vpc_endpoint.secretsmanager
   - SG for interface endpoints and ingress from ECS task SG on 443
2. Refined internal smoke readiness condition:
   - Check PRIMARY deployment rollout state (primary_rollout_state) instead of counting any historical failed deployment.

## Why this is correct
- Private-subnet ECS tasks with no NAT need interface endpoint access to Secrets Manager.
- Smoke checks should not fail solely due to historical failed deployments once PRIMARY is healthy.

## Verification
- 	erraform -chdir=infra/terraform/control-plane validate -no-color passed locally.

Related: #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure security by enabling private access to Secrets Manager.
  * Improved deployment health monitoring with refined status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->