### PR TITLE
fix(terraform): complete private-subnet AWS endpoints for ECS tasks

### DIFF
--- a/infra/terraform/control-plane/main.tf
+++ b/infra/terraform/control-plane/main.tf
@@ -147,7 +147,7 @@ locals {
 }
 
 data "aws_route_table" "endpoint_subnet_route_tables" {
-  for_each  = toset(concat(var.private_subnet_ids, var.public_subnet_ids))
+  for_each  = toset(var.private_subnet_ids)
   subnet_id = each.value
 }
 
@@ -404,6 +404,26 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
 resource "aws_vpc_endpoint" "cloudwatch_logs" {
   vpc_id              = var.vpc_id
   service_name        = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = [aws_security_group.aws_api_endpoints.id]
+  tags                = local.tags
+}
+
+resource "aws_vpc_endpoint" "sqs" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.sqs"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  subnet_ids          = var.private_subnet_ids
+  security_group_ids  = [aws_security_group.aws_api_endpoints.id]
+  tags                = local.tags
+}
+
+resource "aws_vpc_endpoint" "sts" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${var.region}.sts"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
   subnet_ids          = var.private_subnet_ids


### PR DESCRIPTION
## Problem
CodeRabbit feedback on private ECS networking was valid: adding only Secrets Manager endpoint was incomplete for private Fargate tasks and endpoint SG egress rule was redundant.

## Changes
- Removed redundant endpoint SG egress rule (ws_vpc_security_group_egress_rule.aws_api_endpoints_all).
- Added interface endpoints:
  - ws_vpc_endpoint.ecr_api
  - ws_vpc_endpoint.ecr_dkr
  - ws_vpc_endpoint.cloudwatch_logs
- Added S3 gateway endpoint:
  - ws_vpc_endpoint.s3_gateway
- Added route-table discovery from provided subnet IDs:
  - data.aws_route_table.endpoint_subnet_route_tables
  - local.vpc_endpoint_route_table_ids

## Verification
- 	erraform -chdir=infra/terraform/control-plane validate -no-color passes.

Addresses CodeRabbit findings from prior review thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Configured new VPC endpoints for AWS services (ECR, CloudWatch Logs) with private DNS enabled for secure connectivity
  * Added S3 gateway VPC endpoint with automatic route table configuration
  * Enhanced security by restricting unnecessary egress traffic from API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->