### PR TITLE
fix(terraform): handle main-route-table fallback for private subnet endpoint routing

### DIFF
--- a/infra/terraform/control-plane/main.tf
+++ b/infra/terraform/control-plane/main.tf
@@ -91,10 +91,10 @@ locals {
     for subnet_id, route_tables in data.aws_route_tables.private_subnet_route_tables : subnet_id
     if length(route_tables.ids) == 0
   ]
-  vpc_main_route_table_id = data.aws_route_tables.main.ids[0]
+  vpc_main_route_table_id = try(data.aws_route_tables.main.ids[0], null)
   vpc_endpoint_route_table_ids = distinct(concat(
     local.private_subnet_route_table_ids,
-    length(local.private_subnets_without_explicit_route_table) > 0 ? [local.vpc_main_route_table_id] : [],
+    length(local.private_subnets_without_explicit_route_table) > 0 && local.vpc_main_route_table_id != null ? [local.vpc_main_route_table_id] : [],
   ))
 
   api_task_name = substr(replace("${local.name_prefix}-api", "_", "-"), 0, 32)


### PR DESCRIPTION
## Problem
Main deploy failed in `deploy-dev` after PR #113 merge.

Failing run:
- https://github.com/JoshMcQ/SparkPilot/actions/runs/23773327556
- Job: `deploy-dev` -> `Terraform deploy (dev)`
- Error: `query returned no results` for `data.aws_route_table.endpoint_subnet_route_tables[subnet-...]`

Root cause:
- The per-subnet `aws_route_table` data source hard-fails when a private subnet relies on the VPC main route table (no explicit subnet association).

## Changes
- Replaced strict per-subnet `aws_route_table` lookup with resilient `aws_route_tables` lookups:
  - `data.aws_route_tables.private_subnet_route_tables` (explicit subnet associations)
  - `data.aws_route_tables.main` (main route table fallback)
- Updated `local.vpc_endpoint_route_table_ids` to:
  - use explicit private route table IDs when present
  - include main route table only when a private subnet has no explicit association

## Verification
- `terraform -chdir=infra/terraform/control-plane fmt -no-color`
- `terraform -chdir=infra/terraform/control-plane validate -no-color`

## Expected outcome
- `deploy-dev` no longer fails at route-table discovery during Terraform apply.
- S3 gateway endpoint associations resolve cleanly for both explicit and main-associated private subnets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved VPC endpoint route table handling for greater reliability: the infrastructure now gathers route table associations from all private subnets and automatically falls back to the VPC main route table for subnets lacking explicit associations, ensuring VPC endpoints remain reachable across varied subnet configurations and reducing misrouting risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->