### PR TITLE
feat(ui): ship truth-tiered launch messaging across customer surfaces

### DIFF
--- a/ui/app/auth/callback/page.tsx
+++ b/ui/app/auth/callback/page.tsx
@@ -28,7 +28,8 @@ function AuthCallbackContent() {
       .then((nextPath) => {
         // Use a full navigation so middleware reads the freshly persisted
         // HttpOnly session cookie on the first authenticated route load.
-        window.location.assign(nextPath);
+        // replace() prevents users from navigating back to a stale callback URL.
+        window.location.replace(nextPath);
       })
       .catch((err: unknown) => {
         setAsyncError(err instanceof Error ? err.message : "Login failed. Please try again.");

--- a/ui/app/auth/callback/page.tsx
+++ b/ui/app/auth/callback/page.tsx
@@ -2,11 +2,10 @@
 
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { handleCallback } from "@/lib/oidc-client";
 
 function AuthCallbackContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
   const state = searchParams.get("state");
@@ -27,12 +26,14 @@ function AuthCallbackContent() {
 
     handleCallback(code, state)
       .then((nextPath) => {
-        router.replace(nextPath);
+        // Use a full navigation so middleware reads the freshly persisted
+        // HttpOnly session cookie on the first authenticated route load.
+        window.location.assign(nextPath);
       })
       .catch((err: unknown) => {
         setAsyncError(err instanceof Error ? err.message : "Login failed. Please try again.");
       });
-  }, [callbackError, code, state, router]);
+  }, [callbackError, code, state]);
 
   const effectiveError = asyncError ?? callbackError;
 

--- a/ui/app/dashboard/page.tsx
+++ b/ui/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import {
   fetchEnvironments,
+  fetchKpiMetrics,
   fetchRuns,
   fetchUsage,
   type Run,
@@ -14,7 +15,7 @@ import {
 function shortId(value: string): string {
   if (!value) return "-";
   if (value.length <= 12) return value;
-  return `${value.slice(0, 8)}…${value.slice(-4)}`;
+  return `${value.slice(0, 8)}...${value.slice(-4)}`;
 }
 
 function formatUsd(value: number | null): string {
@@ -42,6 +43,9 @@ export default function DashboardPage() {
   const [runRows, setRunRows] = useState<Run[]>([]);
   const [estimatedCostUsd, setEstimatedCostUsd] = useState<number | null>(null);
   const [costRangeLabel, setCostRangeLabel] = useState<string | null>(null);
+  const [preflightPassRatePct, setPreflightPassRatePct] = useState<number | null>(null);
+  const [dispatchSuccessRatePct, setDispatchSuccessRatePct] = useState<number | null>(null);
+  const [jwksForcedRefreshes, setJwksForcedRefreshes] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -55,6 +59,9 @@ export default function DashboardPage() {
 
         let nextEstimatedCostUsd: number | null = null;
         let nextCostRangeLabel: string | null = null;
+        let nextPreflightPassRatePct: number | null = null;
+        let nextDispatchSuccessRatePct: number | null = null;
+        let nextJwksForcedRefreshes: number | null = null;
         if (envData.length > 0) {
           try {
             const usage = await fetchUsage(envData[0].tenant_id);
@@ -62,11 +69,30 @@ export default function DashboardPage() {
               (sum, item) => sum + item.estimated_cost_usd_micros,
               0
             ) / 1_000_000;
-            nextCostRangeLabel = `${formatTimestamp(usage.from_ts)} – ${formatTimestamp(usage.to_ts)}`;
+            nextCostRangeLabel = `${formatTimestamp(usage.from_ts)} - ${formatTimestamp(usage.to_ts)}`;
           } catch {
             nextEstimatedCostUsd = null;
             nextCostRangeLabel = null;
           }
+        }
+        try {
+          const kpis = await fetchKpiMetrics();
+          const preflight = kpis.preflight_outcome_rates as { preflight_pass_rate_pct?: unknown };
+          const dispatch = kpis.dispatch_success_rate as { success_rate_pct?: unknown };
+          const jwks = kpis.jwks_refresh_stats as { forced?: unknown };
+          if (typeof preflight.preflight_pass_rate_pct === "number") {
+            nextPreflightPassRatePct = preflight.preflight_pass_rate_pct;
+          }
+          if (typeof dispatch.success_rate_pct === "number") {
+            nextDispatchSuccessRatePct = dispatch.success_rate_pct;
+          }
+          if (typeof jwks.forced === "number") {
+            nextJwksForcedRefreshes = jwks.forced;
+          }
+        } catch {
+          nextPreflightPassRatePct = null;
+          nextDispatchSuccessRatePct = null;
+          nextJwksForcedRefreshes = null;
         }
 
         if (cancelled) return;
@@ -76,6 +102,9 @@ export default function DashboardPage() {
         setRunning(runData.filter((r) => ["accepted", "running", "dispatching"].includes(r.state)).length);
         setEstimatedCostUsd(nextEstimatedCostUsd);
         setCostRangeLabel(nextCostRangeLabel);
+        setPreflightPassRatePct(nextPreflightPassRatePct);
+        setDispatchSuccessRatePct(nextDispatchSuccessRatePct);
+        setJwksForcedRefreshes(nextJwksForcedRefreshes);
         setError(null);
       } catch (err: unknown) {
         if (!cancelled) {
@@ -129,7 +158,7 @@ export default function DashboardPage() {
       <div className="card">
         <h3>Dashboard</h3>
         <p className="subtle" style={{ marginTop: 8 }}>
-          Live metrics for your SparkPilot environments, runs, and cost tracking.
+          Operational view of environments and runs, with KPI and cost surfaces that are still expanding in validation depth.
         </p>
       </div>
 
@@ -183,6 +212,18 @@ export default function DashboardPage() {
           <h3>Estimated Cost</h3>
           <div className="stat-value">{formatUsd(estimatedCostUsd)}</div>
           <div className="subtle">Usage API summary{costRangeLabel ? ` (${costRangeLabel})` : ""}</div>
+        </article>
+        <article className="card">
+          <h3>KPI Snapshot</h3>
+          <div className="subtle">
+            Preflight pass: {preflightPassRatePct != null ? `${preflightPassRatePct}%` : "N/A"}
+          </div>
+          <div className="subtle">
+            Dispatch success: {dispatchSuccessRatePct != null ? `${dispatchSuccessRatePct}%` : "N/A"}
+          </div>
+          <div className="subtle">
+            JWKS forced refreshes: {jwksForcedRefreshes != null ? jwksForcedRefreshes : "N/A"}
+          </div>
         </article>
       </div>
 
@@ -255,10 +296,11 @@ export default function DashboardPage() {
         </article>
         <article className="card">
           <h3>Workflow Integrations</h3>
-          <p className="subtle">Airflow and Dagster entry points for orchestrated team operations.</p>
+          <p className="subtle">Airflow and Dagster entry points (limited validation for production rollout).</p>
           <Link href="/integrations" className="inline-link">Open integrations &rarr;</Link>
         </article>
       </div>
     </section>
   );
 }
+

--- a/ui/app/getting-started/page.tsx
+++ b/ui/app/getting-started/page.tsx
@@ -170,8 +170,8 @@ export default function GettingStartedPage() {
           </div>
 
           <div className="getting-started-section-title-row">
-            <h2>Command line quickstart (after sign-in)</h2>
-            <p>SparkPilot supports terminal-first batch operations for platform teams and CI workflows.</p>
+            <h2>Command line quickstart (human + automation)</h2>
+            <p>SparkPilot supports terminal-first batch operations for interactive users and service automation.</p>
           </div>
           <div className="getting-started-grid">
             <article className="getting-started-card">
@@ -184,7 +184,10 @@ export default function GettingStartedPage() {
                   </li>
                 ))}
               </ul>
-              <p>CLI auth uses OIDC client-credentials for service-style automation, not browser user sessions.</p>
+              <p>
+                Human CLI path: sign in via the web app first, then run CLI commands for day-to-day operations.
+                Service automation path: use OIDC client-credentials for non-interactive jobs and CI workflows.
+              </p>
             </article>
           </div>
         </div>

--- a/ui/app/getting-started/page.tsx
+++ b/ui/app/getting-started/page.tsx
@@ -42,7 +42,7 @@ const TRACKS = [
     bullets: [
       "Request access or invitation from your SparkPilot admin.",
       "Sign in with SSO and open Start Here onboarding.",
-      "Create/select a job template, submit a run, and verify costs.",
+      "Create/select a job definition, submit a run, and verify costs.",
       "You should not need AWS IAM, CloudFormation, or Terraform access.",
     ],
   },
@@ -108,7 +108,7 @@ export default function GettingStartedPage() {
           <p className="getting-started-sub">
             This page is public and explains where to start. End users sign in and follow authenticated onboarding.
             Platform admins handle one-time
-            workspace setup and access mapping.
+            workspace setup and access mapping for the current batch-first launch scope.
           </p>
           <div className="landing-hero-actions">
             <Link href="/login?next=%2Fonboarding%2Faws" className="landing-btn landing-btn-primary">Sign in and continue</Link>
@@ -116,6 +116,8 @@ export default function GettingStartedPage() {
           </div>
           <div className="getting-started-callout">
             Public flow ends here. Product operations (Onboarding, Environments, Runs, Costs, Access) require sign-in.
+            Interactive endpoints, advanced template/security workflows, Lake Formation depth, and broader runtime parity
+            are not part of the current launch path yet.
           </div>
         </div>
 
@@ -169,7 +171,7 @@ export default function GettingStartedPage() {
 
           <div className="getting-started-section-title-row">
             <h2>Command line quickstart (after sign-in)</h2>
-            <p>SparkPilot supports terminal-first operations for platform teams and CI workflows.</p>
+            <p>SparkPilot supports terminal-first batch operations for platform teams and CI workflows.</p>
           </div>
           <div className="getting-started-grid">
             <article className="getting-started-card">
@@ -182,7 +184,7 @@ export default function GettingStartedPage() {
                   </li>
                 ))}
               </ul>
-              <p>Use the same authenticated workspace context as the dashboard and API.</p>
+              <p>CLI auth uses OIDC client-credentials for service-style automation, not browser user sessions.</p>
             </article>
           </div>
         </div>
@@ -192,3 +194,4 @@ export default function GettingStartedPage() {
     </div>
   );
 }
+

--- a/ui/app/integrations/page.tsx
+++ b/ui/app/integrations/page.tsx
@@ -23,17 +23,17 @@ export default function IntegrationsPage() {
     <section className="stack">
       <div className="card">
         <div className="eyebrow">WORKFLOW INTEGRATIONS</div>
-        <h3>SparkPilot in enterprise workflow operations</h3>
+        <h3>SparkPilot integration surfaces</h3>
         <p className="subtle" style={{ marginTop: 8 }}>
-          This is the in-product integration surface for orchestrator-led operations. Teams submit through Airflow or
-          Dagster, SparkPilot enforces preflight and governance, and operators monitor runs, diagnostics, and costs.
+          The web app, API, and CLI are the primary validated workflow surfaces today.
+          Airflow and Dagster packages exist in-source and are still in limited live validation.
         </p>
       </div>
 
       <div className="card-grid">
         <article className="card">
           <h3>Airflow Provider</h3>
-          <p className="subtle">First-class hook/operator/sensor/trigger provider with deferrable waiting support.</p>
+          <p className="subtle">Hook/operator/sensor/trigger package exists. Production scheduler validation depth is still limited.</p>
           <div className="button-row">
             <a
               href="https://github.com/JoshMcQ/SparkPilot/tree/main/providers/airflow"
@@ -49,7 +49,7 @@ export default function IntegrationsPage() {
 
         <article className="card">
           <h3>Dagster Package</h3>
-          <p className="subtle">Resource + ops + assets for submit/wait/cancel lifecycle with OIDC-authenticated API calls.</p>
+          <p className="subtle">Resource + ops + assets package exists. End-to-end customer runtime validation is still limited.</p>
           <div className="button-row">
             <a
               href="https://github.com/JoshMcQ/SparkPilot/tree/main/providers/dagster"
@@ -65,13 +65,17 @@ export default function IntegrationsPage() {
       </div>
 
       <div className="card">
-        <h3>Operational Workflow Fit</h3>
+        <h3>Current workflow fit</h3>
         <ol className="guided-steps">
-          <li>Platform admin configures identity/team/scope and budget guardrails in Access + Policies.</li>
-          <li>Workflow orchestrator submits SparkPilot runs from Airflow DAGs or Dagster jobs/assets.</li>
-          <li>SparkPilot preflight gates and dispatches; Runs UI is used for state, logs, and diagnostics.</li>
-          <li>Costs UI reconciles team showback from estimated and CUR-backed actual usage.</li>
+          <li>Platform admin configures identity/team scope and validates onboarding gates.</li>
+          <li>Teams submit batch runs through UI, API, or CLI.</li>
+          <li>SparkPilot preflight gates and dispatches runs; Runs UI surfaces state, logs, and diagnostics.</li>
+          <li>Usage and KPI views provide operational evidence while broader cost reconciliation remains environment-dependent.</li>
         </ol>
+        <p className="subtle" style={{ marginTop: 10 }}>
+          Coming soon for customer rollout claims: interactive endpoints, customer-facing template/security workflows,
+          and full multi-engine orchestration guarantees.
+        </p>
         <div className="button-row" style={{ marginTop: 12 }}>
           <Link href="/access" className="button button-secondary">Access</Link>
           <Link href="/policies" className="button button-secondary">Policies</Link>
@@ -82,3 +86,4 @@ export default function IntegrationsPage() {
     </section>
   );
 }
+

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -176,6 +176,7 @@ export default function LandingPage() {
         </p>
       </section>
 
+      <div id="features" />
       <section className="landing-section" id="truth-map">
         <div className="landing-section-header">
           <div className="landing-section-badge">Product Truth Map</div>
@@ -191,6 +192,7 @@ export default function LandingPage() {
         </div>
       </section>
 
+      <div id="integrations" />
       <section className="landing-section landing-section-alt" id="workflow">
         <div className="landing-section-header">
           <div className="landing-section-badge">Validated Workflow</div>
@@ -206,7 +208,7 @@ export default function LandingPage() {
             <Link href="/login?next=%2Fonboarding%2Faws" className="button button-secondary">
               Open sign-in
             </Link>
-            <Link href="/onboarding/aws" className="button button-secondary">
+            <Link href="/login?next=%2Fonboarding%2Faws" className="button button-secondary">
               Open onboarding
             </Link>
             <Link href="/runs" className="button button-secondary">

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,579 +1,272 @@
-"use client";
-
 import Link from "next/link";
-import { useEffect } from "react";
-import { LandingNav } from "@/components/landing-nav";
+import type { ReactNode } from "react";
 import { LandingFooter } from "@/components/landing-footer";
+import { LandingNav } from "@/components/landing-nav";
 import {
-  IconShield,
-  IconDollar,
-  IconCompass,
   IconActivity,
-  IconLayers,
+  IconAlertTriangle,
+  IconCheck,
   IconCloud,
+  IconCompass,
+  IconDollar,
+  IconGitBranch,
+  IconLayers,
   IconLock,
   IconTrendingDown,
-  IconGitBranch,
-  IconCpu,
-  IconCheck,
-  IconX,
-  IconArrowRight,
-  IconAlertTriangle,
 } from "./icons";
 
-/* ── Scroll-reveal hook ─────────────────────────────── */
-function useReveal(selector: string) {
-  useEffect(() => {
-    // Mark document as JS-ready so CSS transitions activate.
-    // Without this class, .reveal elements remain visible (safe fallback).
-    document.documentElement.classList.add("js-reveal-ready");
-    const els = document.querySelectorAll<HTMLElement>(selector);
-    if (!els.length) return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((e) => {
-          if (e.isIntersecting) {
-            (e.target as HTMLElement).classList.add("revealed");
-            io.unobserve(e.target);
-          }
-        });
-      },
-      { threshold: 0.1, rootMargin: "0px 0px -40px 0px" }
-    );
-    els.forEach((el) => io.observe(el));
-    return () => io.disconnect();
-  }, [selector]);
-}
-
-/* ── Data ────────────────────────────────────────────── */
-const FEATURES = [
+const LIVE_NOW = [
   {
-    icon: <IconShield />,
-    title: "Preflight Safety Gates",
+    icon: <IconCheck />,
+    title: "Batch run lifecycle",
     description:
-      "IAM, IRSA, OIDC, resource quota, Spot capacity, and Lake Formation permission checks run before a single byte moves. Bad configs are blocked at the gate with exact remediation steps — no silent failures.",
-  },
-  {
-    icon: <IconDollar />,
-    title: "CUR-Aligned Cost Attribution",
-    description:
-      "Every run gets an estimated cost before dispatch. After completion, SparkPilot reconciles against your real AWS Cost and Usage Report via Athena — not estimates, actual line-item costs attributed to teams.",
-  },
-  {
-    icon: <IconLayers />,
-    title: "Multi-Tenant Isolation",
-    description:
-      "Tenants, teams, environments, and runs are fully scoped. Each environment gets its own namespace, IRSA bindings, and resource quotas. Teams share a cluster without interference.",
-  },
-  {
-    icon: <IconLock />,
-    title: "Governance and Audit",
-    description:
-      "Role-based access (admin, operator, user) enforced on every API endpoint. Team-environment scopes, budget guardrails with warn and block thresholds, and a full audit trail for every action.",
-  },
-  {
-    icon: <IconCloud />,
-    title: "Bring Your Own Cloud",
-    description:
-      "SparkPilot runs inside your AWS account. Your VPC, your S3 buckets, your IAM policies. BYOC-Lite connects an existing EKS cluster in minutes. Full BYOC provisions the entire stack via Terraform.",
-  },
-  {
-    icon: <IconActivity />,
-    title: "Runtime Management",
-    description:
-      "Three background workers — Scheduler, Reconciler, and Provisioner — own the full run lifecycle. SparkPilot dispatches queued jobs to AWS, polls EMR for state transitions, and surfaces deterministic log pointers. You track runs in a dashboard, not a CloudWatch stream.",
-  },
-  {
-    icon: <IconAlertTriangle />,
-    title: "Structured Diagnostics",
-    description:
-      "When a run fails, SparkPilot classifies the cause — OOM kill, Spot interruption, S3 access denied, timeout, unknown user error. Engineers get root cause with remediation context, not raw EMR error codes.",
+      "End-to-end staged flow is live: sign in, submit batch runs, monitor state, open logs, and view diagnostics.",
   },
   {
     icon: <IconCompass />,
-    title: "Guided Onboarding",
+    title: "BYOC-Lite onboarding",
     description:
-      "A step-by-step wizard validates cross-account trust, OIDC federation, namespace prerequisites, and execution role bindings — with exact remediation for every misconfiguration.",
+      "Admins can connect an existing EKS cluster and reach a ready EMR on EKS environment through guided onboarding.",
+  },
+  {
+    icon: <IconLock />,
+    title: "OIDC auth and scoped access",
+    description:
+      "OIDC sign-in and role checks are active in the API and UI for admin/operator/user access boundaries.",
+  },
+  {
+    icon: <IconActivity />,
+    title: "Run operations workspace",
+    description:
+      "Runs page supports job definition creation, run submission, queue/status visibility, logs, and diagnostics.",
+  },
+  {
+    icon: <IconDollar />,
+    title: "Usage and KPI visibility",
+    description:
+      "Usage records and KPI endpoints are wired and visible for staged operational evidence.",
+  },
+];
+
+const LIMITED_VALIDATION = [
+  {
+    icon: <IconGitBranch />,
+    title: "Policy engine",
+    description:
+      "Policy CRUD and preflight evaluation paths are implemented, but enterprise-hardening and broader runtime proof are still in progress.",
   },
   {
     icon: <IconTrendingDown />,
-    title: "Budget Guardrails",
+    title: "CUR reconciliation and budget workflows",
     description:
-      "Set monthly budget limits per team with configurable warn and hard-block thresholds. Submissions that would exceed the block threshold are rejected before any compute runs.",
+      "Cost and budget surfaces are implemented, but customer-by-customer CUR data wiring and validation depth vary.",
   },
   {
-    icon: <IconCpu />,
-    title: "Spot Optimization",
-    description:
-      "Preflight validates Spot instance availability, instance type diversification, and executor placement before dispatch. No wasted job starts on under-provisioned Spot nodegroups.",
-  },
-  {
-    icon: <IconGitBranch />,
-    title: "Policy Engine",
-    description:
-      "Define submission guardrails as policy rules — restrict instance types, enforce release labels, require cost center tags, or block teams from exceeding vCPU limits. Applied at preflight before dispatch.",
-  },
-];
-
-const BEFORE_AFTER = [
-  {
-    before: "Manually validate IAM trust policy and OIDC association before every job",
-    after: "SparkPilot checks 15+ conditions automatically — fails fast with remediation steps",
-  },
-  {
-    before: "Hunt through 6 different CloudWatch log groups to find your job output",
-    after: "Every run has a deterministic log pointer. One click to the right stream",
-  },
-  {
-    before: "Estimate cost in a spreadsheet after the job finishes",
-    after: "CUR-aligned cost is attributed to your team automatically, reconciled against real AWS billing",
-  },
-  {
-    before: "Engineers share a cluster namespace with no isolation or quota enforcement",
-    after: "Each team gets scoped access, resource quotas, and budget guardrails",
-  },
-  {
-    before: "Debug Spot interruptions by reading EMR service events manually",
-    after: "Spot capacity and diversification are validated before the job starts",
-  },
-  {
-    before: "Write one-off Terraform for every new EKS-based Spark deployment",
-    after: "SparkPilot provisions network, EKS, and EMR from a versioned, reproducible control plane",
-  },
-  {
-    before: "Poll EMR DescribeJobRun in a cron loop to know when your job finishes",
-    after: "SparkPilot's Reconciler polls EMR continuously and writes structured state transitions — queued → running → succeeded",
-  },
-  {
-    before: "Parse raw EMR error events to understand why a job failed",
-    after: "SparkPilot classifies failures — OOM, Spot interruption, S3 access denied, timeout — with remediation context",
-  },
-];
-
-const ENGINES = [
-  {
-    name: "EMR on EKS",
-    badge: "Proven",
-    badgeClass: "badge-proven",
-    desc: "Native EMR virtual cluster on your EKS cluster. Validated end-to-end with real workloads including Structured Streaming.",
-  },
-  {
-    name: "EMR Serverless",
-    badge: "Supported",
-    badgeClass: "badge-supported",
-    desc: "Submit to an EMR Serverless application for fully managed capacity. No EKS cluster required.",
-  },
-  {
-    name: "EMR on EC2",
-    badge: "Supported",
-    badgeClass: "badge-supported",
-    desc: "Dispatch to existing EMR on EC2 clusters via step submission. Integrates with your current EC2-based Spark estate.",
-  },
-  {
-    name: "Databricks on AWS",
-    badge: "Supported",
-    badgeClass: "badge-supported",
-    desc: "Submit to a Databricks workspace via the Jobs API. Unified control plane for mixed Databricks and EMR environments.",
-  },
-];
-
-const INTEGRATIONS = [
-  {
-    name: "Apache Airflow",
-    desc: "SparkPilotSubmitRunOperator with full deferrable trigger support. Drop into any existing DAG - sync or async.",
-    detail: "Operator | Hook | Sensor | Async Trigger",
-  },
-  {
-    name: "Dagster",
-    desc: "Native @asset definitions and ops for run submission, polling, and cancellation. Works with Dagster Cloud and OSS.",
-    detail: "Assets | Ops | Config Schema",
-  },
-  {
-    name: "SparkPilot CLI",
-    desc: "Engineers can submit, inspect, cancel, and tail runs from terminal workflows without opening the dashboard.",
-    detail: "run-submit | run-list | run-logs | usage-get",
-  },
-  {
-    name: "SparkPilot API",
-    desc: "Teams can integrate SparkPilot into internal portals and automation jobs through authenticated REST endpoints.",
-    detail: "REST API | RBAC | Audit Trail",
-  },
-];
-const RUN_STATES = [
-  { label: "queued", terminal: false },
-  { label: "dispatching", terminal: false },
-  { label: "accepted", terminal: false },
-  { label: "running", terminal: false },
-];
-const RUN_TERMINAL_STATES = ["succeeded", "failed", "cancelled", "timed_out"];
-
-const WORKERS = [
-  {
-    name: "Scheduler",
-    icon: <IconCpu />,
-    desc: "Polls for queued runs and dispatches them to AWS EMR, EMR Serverless, EMR on EC2, or Databricks. Manages concurrency limits and environment-level queueing.",
-  },
-  {
-    name: "Reconciler",
-    icon: <IconActivity />,
-    desc: "Continuously polls EMR for job state changes and writes structured transitions — accepted → running → succeeded/failed. Detects stalled runs and triggers timeout handling.",
-  },
-  {
-    name: "Provisioner",
     icon: <IconLayers />,
-    desc: "Manages environment lifecycle — BYOC-Lite and Full BYOC provisioning, checkpoint recovery across Terraform stages, and environment teardown.",
+    title: "Lake Formation and queue signals",
+    description:
+      "Lake Formation preflight logic and queue utilization APIs exist, but customer-facing rollout proof is still limited by environment-specific setup.",
+  },
+  {
+    icon: <IconCloud />,
+    title: "Orchestration packages",
+    description:
+      "Airflow and Dagster providers are implemented in-source, with narrower live validation for customer production rollout.",
   },
 ];
 
-const HOW_IT_WORKS = [
+const COMING_SOON = [
   {
-    step: "1",
-    title: "Connect your AWS account",
+    icon: <IconAlertTriangle />,
+    title: "Interactive endpoints",
     description:
-      "Create a cross-account IAM role and OIDC association. SparkPilot validates the trust relationship, required permissions, and namespace prerequisites automatically — with exact remediation for every failure. Supports Cognito, Auth0, Okta, and any standards-compliant OIDC provider.",
-    docLink: { href: "/getting-started", label: "Start here onboarding guide" },
+      "Endpoint APIs exist, but interactive governance controls and operational maturity are not yet launch-ready.",
   },
   {
-    step: "2",
-    title: "Choose your deployment model",
+    icon: <IconCloud />,
+    title: "Multi-engine runtime parity",
     description:
-      "BYOC-Lite connects to an existing EKS cluster and provisions the EMR virtual cluster in minutes. Full BYOC runs Terraform to provision VPC, EKS, and EMR from scratch — with checkpoint recovery if any stage fails.",
+      "Serverless, EMR on EC2, and Databricks code paths exist in backend routing but are not yet proven launch workflows.",
   },
   {
-    step: "3",
-    title: "Define job templates",
+    icon: <IconAlertTriangle />,
+    title: "Template and security workflows",
     description:
-      "Encode submission patterns as versioned templates — Spot configurations, Graviton instance preferences, S3 Express paths, container images, and Spark configuration golden paths.",
-  },
-  {
-    step: "4",
-    title: "Submit through your orchestrator",
-    description:
-      "Push jobs through the SparkPilot API, the SparkPilot CLI, the Airflow operator, or the Dagster asset. Every submission passes preflight gates, gets a cost estimate, and is dispatched with deterministic logging.",
-  },
-  {
-    step: "5",
-    title: "Track cost and usage",
-    description:
-      "Estimated costs appear immediately. After the job finishes, SparkPilot reconciles against your AWS Cost and Usage Report via Athena — actual line-item costs attributed to teams and environments.",
+      "Job template, security configuration, and YuniKorn queue controls need stronger customer-facing UX and rollout evidence before launch claims.",
   },
 ];
 
-const COMPARE_ROWS = [
-  { topic: "Preflight IAM/OIDC validation", diy: false, serverless: false, sp: true },
-  { topic: "Multi-tenant namespace isolation on EKS", diy: false, serverless: false, sp: true },
-  { topic: "CUR-aligned cost attribution per team", diy: false, serverless: false, sp: true },
-  { topic: "Budget guardrails with hard-block", diy: false, serverless: false, sp: true },
-  { topic: "Spot diversification validation at preflight", diy: false, serverless: false, sp: true },
-  { topic: "Airflow and Dagster native integrations", diy: false, serverless: false, sp: true },
-  { topic: "Lake Formation FGAC permission validation", diy: false, serverless: false, sp: true },
-  { topic: "Policy engine for submission guardrails", diy: false, serverless: false, sp: true },
-  { topic: "Kubernetes-native control plane", diy: true, serverless: false, sp: true },
-  { topic: "Background Reconciler with structured state transitions", diy: false, serverless: false, sp: true },
-  { topic: "Automated failure classification (OOM, Spot, access denied)", diy: false, serverless: false, sp: true },
-  { topic: "No infra management required", diy: false, serverless: true, sp: false },
-  { topic: "Sub-minute job start time", diy: false, serverless: true, sp: false },
+const WORKFLOW = [
+  "Sign in with SSO and verify identity mapping.",
+  "Create or connect a BYOC-Lite environment.",
+  "Create a job definition and submit a run.",
+  "Track lifecycle, logs, diagnostics, and usage evidence.",
 ];
 
-/* ── Page ────────────────────────────────────────────── */
+const LAUNCH_SCOPE = [
+  "Batch-first governance on EMR on EKS",
+  "SSO sign-in and role-scoped product access",
+  "BYOC-Lite environment connection",
+  "Run submission and state monitoring",
+  "Logs, diagnostics, usage, and KPI basics",
+];
+
+const NOT_LAUNCH_SCOPE = [
+  "Interactive notebook endpoints",
+  "Job template and security configuration management workflows",
+  "Lake Formation and YuniKorn customer-facing operations",
+  "Full multi-engine customer parity",
+  "Enterprise compliance packaging claims",
+  "Broad orchestration-runtime guarantees beyond staged proof",
+];
+
+function CapabilityColumn({
+  title,
+  subtitle,
+  rows,
+}: {
+  title: string;
+  subtitle: string;
+  rows: { icon: ReactNode; title: string; description: string }[];
+}) {
+  return (
+    <div className="landing-engine-card reveal">
+      <div className="landing-engine-header">
+        <strong>{title}</strong>
+      </div>
+      <p className="landing-section-sub">{subtitle}</p>
+      <div className="landing-features-grid" style={{ marginTop: "16px" }}>
+        {rows.map((row) => (
+          <article key={row.title} className="landing-feature-card">
+            <div className="landing-feature-icon">{row.icon}</div>
+            <h3>{row.title}</h3>
+            <p>{row.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function LandingPage() {
-  useReveal(".reveal");
-
   return (
     <div className="landing">
       <LandingNav />
 
-      {/* ── Hero ─────────────────────────────────────── */}
       <section className="landing-hero" id="hero">
-        <div className="landing-hero-badge">AWS-native Spark Control Plane</div>
+        <div className="landing-hero-badge">AWS-first batch governance control plane</div>
         <h2 className="landing-hero-title">
-          Stop firefighting Spark.<br />
-          <span className="landing-hero-accent">Ship with confidence.</span>
+          SparkPilot launch scope is now <br />
+          <span className="landing-hero-accent">explicit and evidence-backed</span>
         </h2>
         <p className="landing-hero-sub">
-          Data engineers submit a job — SparkPilot handles everything else. Preflight
-          validation, AWS dispatch, real-time run tracking, structured failure diagnostics,
-          and CUR-aligned cost attribution. One control plane for the full Spark lifecycle,
-          inside your AWS account.
+          SparkPilot is focused on one honest story for launch: governed batch Spark operations in your AWS account.
+          We separate what is live now from what is beta and what is still coming soon.
         </p>
         <div className="landing-hero-actions">
-          <Link href="/contact" className="landing-btn landing-btn-primary">
-            Request access
+          <Link href="/getting-started" className="landing-btn landing-btn-primary">
+            Start with staged flow
           </Link>
-          <Link href="/#how-it-works" className="landing-btn landing-btn-secondary">
-            See how it works
+          <Link href="/pricing" className="landing-btn landing-btn-secondary">
+            View scope and plans
           </Link>
         </div>
         <p className="landing-hero-note">
-          Runs in your AWS account · No data leaves your perimeter · BYOC-Lite or Full BYOC
+          BYOC-Lite is the current validated path. Full BYOC and broader engine coverage are limited validation.
         </p>
       </section>
 
-      {/* ── Before / After ───────────────────────────── */}
-      <section className="landing-section landing-section-tight" id="before-after">
+      <section className="landing-section" id="truth-map">
         <div className="landing-section-header">
-          <div className="landing-section-badge">The Problem</div>
-          <h2 className="landing-section-title">Before SparkPilot, this was your day</h2>
+          <div className="landing-section-badge">Product Truth Map</div>
+          <h2 className="landing-section-title">Live now, limited validation, and coming soon</h2>
           <p className="landing-section-sub">
-            Every team with a shared EKS cluster and a Spark workload hits the same walls.
-            SparkPilot eliminates them operationally, not just conceptually.
+            Capability labels are tied to current staging evidence and implementation depth.
           </p>
+        </div>
+        <div className="landing-engines-grid">
+          <CapabilityColumn title="Live now" subtitle="Validated in staged customer workflow." rows={LIVE_NOW} />
+          <CapabilityColumn title="Limited validation / beta" subtitle="Implemented with narrower live proof." rows={LIMITED_VALIDATION} />
+          <CapabilityColumn title="Coming soon" subtitle="Do not treat as launch commitments yet." rows={COMING_SOON} />
+        </div>
+      </section>
+
+      <section className="landing-section landing-section-alt" id="workflow">
+        <div className="landing-section-header">
+          <div className="landing-section-badge">Validated Workflow</div>
+          <h2 className="landing-section-title">Current end-to-end customer path</h2>
+        </div>
+        <div className="landing-step reveal">
+          <ol className="guided-steps">
+            {WORKFLOW.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+          <div className="button-row" style={{ marginTop: "12px" }}>
+            <Link href="/login?next=%2Fonboarding%2Faws" className="button button-secondary">
+              Open sign-in
+            </Link>
+            <Link href="/onboarding/aws" className="button button-secondary">
+              Open onboarding
+            </Link>
+            <Link href="/runs" className="button button-secondary">
+              Open runs
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-section" id="scope">
+        <div className="landing-section-header">
+          <div className="landing-section-badge">Launch Scope</div>
+          <h2 className="landing-section-title">What is in and out for near-term launch</h2>
         </div>
         <div className="landing-before-after-grid">
-          {BEFORE_AFTER.map((row) => (
-            <div key={row.before} className="landing-ba-row reveal">
-              <div className="landing-ba-before">
-                <span className="landing-ba-icon landing-ba-icon-no" aria-hidden><IconX /></span>
-                <span>{row.before}</span>
-              </div>
-              <div className="landing-ba-arrow" aria-hidden>→</div>
-              <div className="landing-ba-after">
-                <span className="landing-ba-icon landing-ba-icon-yes" aria-hidden><IconCheck /></span>
-                <span>{row.after}</span>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Features ─────────────────────────────────── */}
-      <section className="landing-section" id="features">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Capabilities</div>
-          <h2 className="landing-section-title">Everything your platform team needs</h2>
-          <p className="landing-section-sub">
-            Each capability is fully implemented and validated on real AWS — not
-            checkbox features or marketing claims.
-          </p>
-        </div>
-        <div className="landing-features-grid">
-          {FEATURES.map((f, i) => (
-            <article
-              key={f.title}
-              className="landing-feature-card reveal"
-              style={{ transitionDelay: `${(i % 3) * 60}ms` } as React.CSSProperties}
-            >
-              <div className="landing-feature-icon">{f.icon}</div>
-              <h3>{f.title}</h3>
-              <p>{f.description}</p>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Run Lifecycle ────────────────────────────── */}
-      <section className="landing-section landing-section-alt" id="lifecycle">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Run Lifecycle</div>
-          <h2 className="landing-section-title">SparkPilot calls AWS — you don&apos;t have to</h2>
-          <p className="landing-section-sub">
-            Submit a job through the SparkPilot API, SparkPilot CLI, Airflow, or Dagster. Three background
-            workers handle dispatch, state reconciliation, and environment provisioning.
-            Your data engineers interact with SparkPilot — not directly with AWS.
-          </p>
-        </div>
-
-        {/* State machine */}
-        <div className="reveal" style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "center", gap: "6px", padding: "18px 24px", background: "var(--surface-1)", border: "1px solid var(--line-soft)", borderRadius: "var(--radius-lg)", marginBottom: "32px", maxWidth: "760px", margin: "0 auto 32px" } as React.CSSProperties}>
-          {RUN_STATES.map((s) => (
-            <span key={s.label} style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
-              <span style={{ fontSize: "0.76rem", fontWeight: 600, letterSpacing: "0.03em", padding: "3px 11px", borderRadius: "999px", background: "var(--surface-2)", border: "1px solid var(--line-soft)", color: "var(--text-soft)" }}>
-                {s.label}
+          <div className="landing-ba-row reveal">
+            <div className="landing-ba-before">
+              <span className="landing-ba-icon landing-ba-icon-yes" aria-hidden>
+                <IconCheck />
               </span>
-              <span style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>→</span>
-            </span>
-          ))}
-          <span style={{ fontSize: "0.76rem", fontWeight: 600, letterSpacing: "0.03em", padding: "3px 11px", borderRadius: "999px", background: "var(--surface-2)", border: "1px solid var(--line-soft)", color: "var(--text-muted)" }}>
-            {RUN_TERMINAL_STATES.join(" · ")}
-          </span>
-        </div>
-
-        {/* Workers */}
-        <div className="landing-engines-grid">
-          {WORKERS.map((w) => (
-            <div key={w.name} className="landing-engine-card reveal">
-              <div className="landing-engine-header">
-                <div className="landing-feature-icon">{w.icon}</div>
-                <strong>{w.name}</strong>
-              </div>
-              <p>{w.desc}</p>
+              <span>In launch scope</span>
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Engines ──────────────────────────────────── */}
-      <section className="landing-section" id="engines">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Supported Engines</div>
-          <h2 className="landing-section-title">One control plane, four Spark runtimes</h2>
-          <p className="landing-section-sub">
-            SparkPilot routes submissions to EMR on EKS, EMR Serverless, EMR on EC2, or
-            Databricks — from the same API and the same preflight pipeline.
-          </p>
-        </div>
-        <div className="landing-engines-grid">
-          {ENGINES.map((e) => (
-            <div key={e.name} className="landing-engine-card reveal">
-              <div className="landing-engine-header">
-                <strong>{e.name}</strong>
-                <span className={`landing-engine-badge ${e.badgeClass}`}>{e.badge}</span>
-              </div>
-              <p>{e.desc}</p>
+            <div className="landing-ba-after">
+              <ul className="contact-expect-list">
+                {LAUNCH_SCOPE.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
             </div>
-          ))}
-        </div>
-        <p className="landing-engines-note">
-          <strong>Proven</strong> = validated end-to-end on real AWS with real run IDs and CloudWatch output.&nbsp;
-          <strong>Supported</strong> = dispatch code is implemented and routed; live end-to-end validation in progress.
-        </p>
-      </section>
-
-      {/* ── How It Works ─────────────────────────────── */}
-      <section className="landing-section" id="how-it-works">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">How It Works</div>
-          <h2 className="landing-section-title">From zero to production in five steps</h2>
-        </div>
-        <div className="landing-steps landing-steps-5">
-          {HOW_IT_WORKS.map((s, i) => (
-            <div key={s.step} className="landing-step reveal" style={{ transitionDelay: `${i * 70}ms` } as React.CSSProperties}>
-              <div className="landing-step-number">{s.step}</div>
-              <div className="landing-step-body">
-                <h3>{s.title}</h3>
-                <p>{s.description}</p>
-                {"docLink" in s && s.docLink ? (
-                  <Link href={s.docLink.href} className="landing-step-doc-link">
-                    {s.docLink.label} →
-                  </Link>
-                ) : null}
-              </div>
+          </div>
+          <div className="landing-ba-row reveal">
+            <div className="landing-ba-before">
+              <span className="landing-ba-icon landing-ba-icon-no" aria-hidden>
+                <IconAlertTriangle />
+              </span>
+              <span>Not launch scope yet</span>
             </div>
-          ))}
-        </div>
-      </section>
-
-      {/* ── Integrations ─────────────────────────────── */}
-      <section className="landing-section landing-section-alt" id="integrations">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Integrations and Interfaces</div>
-          <h2 className="landing-section-title">Use SparkPilot from orchestrators, terminal, or API</h2>
-          <p className="landing-section-sub">
-            SparkPilot supports workflow engines and engineer-first interfaces, so teams can
-            adopt it through existing DAGs, CI pipelines, and terminal-driven operations.
-          </p>
-        </div>
-        <div className="landing-integrations-grid">
-          {INTEGRATIONS.map((intg) => (
-            <div key={intg.name} className="landing-integration-card reveal">
-              <div className="landing-integration-name">{intg.name}</div>
-              <p className="landing-integration-desc">{intg.desc}</p>
-              <div className="landing-integration-detail">{intg.detail}</div>
+            <div className="landing-ba-after">
+              <ul className="contact-expect-list">
+                {NOT_LAUNCH_SCOPE.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
             </div>
-          ))}
-        </div>
-        <div className="landing-integrations-note reveal">
-          Airflow and Dagster providers are installable from source today. CLI and API are available now for platform teams and automation.
+          </div>
         </div>
       </section>
 
-      {/* ── Comparison ───────────────────────────────── */}
-      <section className="landing-section" id="compare">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Why SparkPilot</div>
-          <h2 className="landing-section-title">What you don&apos;t get with DIY or EMR Serverless</h2>
-          <p className="landing-section-sub">
-            DIY gives you primitives. EMR Serverless removes cluster management.
-            Neither gives you a multi-tenant control plane with built-in governance.
-          </p>
-        </div>
-        <div className="landing-compare-wrapper reveal">
-          <table className="landing-compare-table">
-            <thead>
-              <tr>
-                <th className="landing-compare-topic">Capability</th>
-                <th>DIY on AWS</th>
-                <th>EMR Serverless</th>
-                <th className="landing-compare-sp">SparkPilot</th>
-              </tr>
-            </thead>
-            <tbody>
-              {COMPARE_ROWS.map((row) => (
-                <tr key={row.topic}>
-                  <td className="landing-compare-topic">{row.topic}</td>
-                  <td>
-                    <span role="img" className={`landing-compare-cell ${row.diy ? "cell-yes" : "cell-no"}`} aria-label={row.diy ? "Yes" : "No"}>
-                      {row.diy ? <IconCheck /> : <IconX />}
-                    </span>
-                  </td>
-                  <td>
-                    <span role="img" className={`landing-compare-cell ${row.serverless ? "cell-yes" : "cell-no"}`} aria-label={row.serverless ? "Yes" : "No"}>
-                      {row.serverless ? <IconCheck /> : <IconX />}
-                    </span>
-                  </td>
-                  <td>
-                    <span role="img" className={`landing-compare-cell ${row.sp ? "cell-yes" : "cell-no"}`} aria-label={row.sp ? "Yes" : "No"}>
-                      {row.sp ? <IconCheck /> : <IconX />}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-        <div className="landing-compare-caveat">
-          This comparison reflects capabilities of the SparkPilot control plane, not the
-          underlying AWS services. Rows marked with ✓ for DIY reflect platform primitives
-          you can build yourself — SparkPilot ships them configured and enforced.
-        </div>
-      </section>
-
-      {/* ── Learn More ───────────────────────────────── */}
-      <section className="landing-section" id="learn-more">
-        <div className="landing-section-header">
-          <div className="landing-section-badge">Still evaluating?</div>
-          <h2 className="landing-section-title">Common questions, honest answers</h2>
-          <p className="landing-section-sub">
-            We document the real tradeoffs. No marketing spin — so you can make the right
-            call for your team.
-          </p>
-        </div>
-        <div className="landing-learnmore-grid">
-          <Link href="/why-not-diy" className="landing-learnmore-card">
-            <div className="landing-learnmore-icon">🔧</div>
-            <h3>Why not build it yourself?</h3>
-            <p>
-              130–250 hours to reach parity. 40–80 hours of ongoing maintenance per month.
-              An honest cost accounting of DIY EMR on EKS.
-            </p>
-            <span className="landing-learnmore-link">Read the breakdown →</span>
-          </Link>
-          <Link href="/why-not-serverless" className="landing-learnmore-card">
-            <div className="landing-learnmore-icon">☁️</div>
-            <h3>Why not EMR Serverless?</h3>
-            <p>
-              Cold-start latency, no persistent clusters, no YuniKorn, no BYOC. When
-              Serverless is the right answer — and when it isn&apos;t.
-            </p>
-            <span className="landing-learnmore-link">Read the tradeoffs →</span>
-          </Link>
-        </div>
-      </section>
-
-      {/* ── CTA ──────────────────────────────────────── */}
       <section className="landing-cta">
-        <h2>Ready to stop firefighting Spark?</h2>
+        <h2>Need a realistic pilot path?</h2>
         <p>
-          Talk to us about your setup. We&apos;ll tell you honestly whether
-          SparkPilot is the right fit for your team.
+          Start with the staged batch-first workflow, validate against your own BYOC setup, then expand capability
+          claims only after live evidence exists.
         </p>
         <div className="landing-hero-actions">
-          <Link href="/contact" className="landing-btn landing-btn-primary">
-            <span>Talk to us</span>
-            <span className="landing-btn-arrow"><IconArrowRight /></span>
+          <Link href="/getting-started" className="landing-btn landing-btn-primary">
+            Open getting started
           </Link>
-          <Link href="/pricing" className="landing-btn landing-btn-secondary">
-            View pricing
+          <Link href="/contact" className="landing-btn landing-btn-secondary">
+            Talk to us
           </Link>
         </div>
       </section>
@@ -582,3 +275,4 @@ export default function LandingPage() {
     </div>
   );
 }
+

--- a/ui/app/policies/page.tsx
+++ b/ui/app/policies/page.tsx
@@ -44,7 +44,7 @@ const RULE_TYPE_DESCRIPTIONS: Record<PolicyRuleType, string> = {
   required_tags:
     "Require specific Spark tags (e.g. cost_center, project) on every submission.",
   allowed_golden_paths:
-    "Restrict submissions to a specific set of job template golden paths.",
+    "Restrict submissions to a specific set of approved job-definition golden paths.",
   allowed_release_labels:
     "Allow only specific EMR release labels (e.g. emr-7.2.0). Blocks deprecated or EOL releases.",
   allowed_instance_types:
@@ -77,8 +77,8 @@ function enforcementBadge(enforcement: PolicyEnforcement, active: boolean) {
 
 function scopeLabel(scope: PolicyScope, scopeId: string | null): string {
   if (scope === "global") return "Global";
-  if (scope === "tenant") return `Tenant ${scopeId ? scopeId.slice(0, 8) : "—"}`;
-  return `Environment ${scopeId ? scopeId.slice(0, 8) : "—"}`;
+  if (scope === "tenant") return `Tenant ${scopeId ? scopeId.slice(0, 8) : "-"}`;
+  return `Environment ${scopeId ? scopeId.slice(0, 8) : "-"}`;
 }
 
 function configSummary(ruleType: PolicyRuleType, config: Record<string, unknown>): string {
@@ -88,23 +88,23 @@ function configSummary(ruleType: PolicyRuleType, config: Record<string, unknown>
     }
     if (ruleType === "required_tags") {
       const tags = config.tags;
-      return Array.isArray(tags) && tags.length > 0 ? tags.map(String).join(", ") : "—";
+      return Array.isArray(tags) && tags.length > 0 ? tags.map(String).join(", ") : "-";
     }
     if (ruleType === "allowed_golden_paths") {
       const paths = config.paths;
-      return Array.isArray(paths) && paths.length > 0 ? paths.map(String).join(", ") : "—";
+      return Array.isArray(paths) && paths.length > 0 ? paths.map(String).join(", ") : "-";
     }
     if (ruleType === "allowed_release_labels") {
       const labels = config.labels;
-      return Array.isArray(labels) && labels.length > 0 ? labels.map(String).join(", ") : "—";
+      return Array.isArray(labels) && labels.length > 0 ? labels.map(String).join(", ") : "-";
     }
     if (ruleType === "allowed_instance_types") {
       const types = config.types;
-      return Array.isArray(types) && types.length > 0 ? types.map(String).join(", ") : "—";
+      return Array.isArray(types) && types.length > 0 ? types.map(String).join(", ") : "-";
     }
     return JSON.stringify(config);
   } catch {
-    return "—";
+    return "-";
   }
 }
 
@@ -222,8 +222,8 @@ function CreatePolicyForm({
             value={form.enforcement}
             onChange={(e) => setForm((f) => ({ ...f, enforcement: e.target.value as PolicyEnforcement }))}
           >
-            <option value="hard">Hard block — reject submission</option>
-            <option value="soft">Soft warn — allow with warning</option>
+            <option value="hard">Hard block - reject submission</option>
+            <option value="soft">Soft warn - allow with warning</option>
           </select>
         </label>
 
@@ -236,9 +236,9 @@ function CreatePolicyForm({
               setForm((f) => ({ ...f, scope, scope_id: null }));
             }}
           >
-            <option value="global">Global — applies to all tenants</option>
-            <option value="tenant">Tenant — applies to one tenant</option>
-            <option value="environment">Environment — applies to one environment</option>
+            <option value="global">Global - applies to all tenants</option>
+            <option value="tenant">Tenant - applies to one tenant</option>
+            <option value="environment">Environment - applies to one environment</option>
           </select>
         </label>
 
@@ -322,7 +322,7 @@ const POLICY_WORKFLOW = [
   "Hard-block policies reject the submission with a clear error and the policy name.",
   "Soft-warn policies allow the submission but record the warning in the run audit trail.",
   "Policies apply to all scopes below them: a global policy applies everywhere; a tenant policy applies to all environments in that tenant.",
-  "The policy engine is active in production. Creating a hard-block policy with an incorrect config will block real submissions.",
+  "Policy behavior is active in environments where policy checks are enabled. Validate policy configs in staging before broad rollout.",
 ];
 
 export default function PoliciesPage() {
@@ -366,7 +366,8 @@ export default function PoliciesPage() {
         <h3>Policy Engine</h3>
         <div className="subtle">
           Submission guardrails evaluated at preflight before every run. Hard-block policies reject
-          submissions; soft-warn policies allow with a warning recorded in the audit trail.
+          submissions; soft-warn policies allow with a warning recorded in the audit trail. This
+          surface is in limited-validation status for staged rollout.
         </div>
       </div>
 
@@ -451,3 +452,4 @@ export default function PoliciesPage() {
     </section>
   );
 }
+

--- a/ui/app/pricing/page.tsx
+++ b/ui/app/pricing/page.tsx
@@ -1,94 +1,83 @@
-"use client";
-
 import Link from "next/link";
-import { LandingNav } from "@/components/landing-nav";
 import { LandingFooter } from "@/components/landing-footer";
+import { LandingNav } from "@/components/landing-nav";
 
 const TIERS = [
   {
-    name: "Community",
+    name: "Open Source",
     price: "Free",
-    period: "forever",
-    description: "Self-hosted on your own infrastructure. Everything you need to get started.",
-    cta: "Get started",
+    period: "self-hosted",
+    description: "Code access and local development workflows.",
+    cta: "View repository",
     ctaHref: "https://github.com/JoshMcQ/SparkPilot",
     ctaStyle: "landing-btn-secondary",
     featured: false,
     features: [
-      "Single tenant",
-      "Up to 3 environments",
-      "BYOC-Lite provisioning",
-      "20+ preflight safety checks",
-      "Run lifecycle management",
-      "Cost estimation",
-      "Airflow & Dagster providers",
-      "Community support (GitHub)",
+      "Core API and UI codebase",
+      "CLI and provider source packages",
+      "Local and mocked test workflows",
+      "No hosted SLA commitments",
     ],
   },
   {
-    name: "Team",
-    price: "Contact us",
+    name: "Staging Pilot",
+    price: "Current focus",
     period: "",
-    description: "Supported deployment for growing data platform teams with production SLAs.",
-    cta: "Talk to us",
-    ctaHref: "/contact",
+    description: "Validated, batch-first staged workflow for real customer-style trials.",
+    cta: "Start staging flow",
+    ctaHref: "/getting-started",
     ctaStyle: "landing-btn-primary",
     featured: true,
     features: [
-      "Multi-tenant",
-      "Unlimited environments",
-      "BYOC-Lite provisioning",
-      "Full preflight + diagnostics suite",
-      "CUR cost reconciliation",
-      "Team budget enforcement",
-      "Policy engine",
-      "Email support with SLA",
-      "Deployment assistance",
-      "Private Slack channel",
+      "OIDC sign-in and onboarding",
+      "BYOC-Lite environment connection",
+      "Batch run submit, monitor, logs, diagnostics",
+      "Usage and KPI visibility",
+      "Policy and governance basics (limited validation)",
+      "Advanced runtime features clearly labeled as beta or coming soon",
     ],
   },
   {
-    name: "Enterprise",
-    price: "Custom",
+    name: "Enterprise Expansion",
+    price: "Coming soon",
     period: "",
-    description: "For organizations with compliance requirements, advanced security, and scale.",
-    cta: "Contact sales",
+    description: "Broader multi-engine and enterprise packaging after additional live validation.",
+    cta: "Talk to us",
     ctaHref: "/contact",
     ctaStyle: "landing-btn-secondary",
     featured: false,
     features: [
-      "Everything in Team",
-      "SSO / SAML integration",
-      "Custom RBAC policies",
-      "Audit log export",
-      "SOC 2 documentation",
-      "Dedicated support engineer",
-      "Custom SLA",
-      "Procurement & legal review",
+      "Interactive endpoints maturity",
+      "Customer-facing job template workflows",
+      "Security configuration workflows",
+      "Lake Formation and YuniKorn rollout depth",
+      "Broader runtime parity",
+      "Expanded compliance and support packaging",
+      "Only announced after evidence-backed readiness",
     ],
   },
 ];
 
 const FAQ = [
   {
-    q: "Does SparkPilot have access to my AWS account?",
-    a: "No. SparkPilot runs inside your AWS account using a cross-account IAM role you provision. Your Spark job data, S3 buckets, and VPC resources never leave your perimeter.",
+    q: "Is SparkPilot fully production-wide today?",
+    a: "Not yet. The current honest scope is a staged, batch-first workflow with clearly marked beta and coming-soon areas.",
   },
   {
-    q: "What does BYOC mean?",
-    a: "Bring Your Own Cloud. You provide the EKS cluster and IAM setup. SparkPilot registers your environment, validates prerequisites, and dispatches jobs — all within your account.",
+    q: "What is the best path to evaluate right now?",
+    a: "Use the staging flow end-to-end: sign in, onboard, connect BYOC-Lite environment, submit a run, and verify logs/diagnostics/usage.",
   },
   {
-    q: "What AWS services does SparkPilot require?",
-    a: "EMR on EKS (virtual cluster), EKS (your cluster), IAM (cross-account role + IRSA bindings), CloudWatch (log retrieval), and optionally Athena + S3 for CUR cost reconciliation.",
+    q: "Are all backend features customer-ready?",
+    a: "No. Some backend capabilities exist without full customer-surface or live validation yet; those are marked as beta or coming soon.",
   },
   {
-    q: "Is there a free trial for the Team plan?",
-    a: "Yes. We offer a 30-day evaluation for qualifying teams. Get in touch and we'll set you up.",
+    q: "How are advanced features currently classified?",
+    a: "Interactive endpoints, template/security workflows, Lake Formation depth, YuniKorn controls, and broader orchestration rollout are currently beta or coming soon unless explicitly proven.",
   },
   {
-    q: "Can I self-host the Team or Enterprise version?",
-    a: "Yes. SparkPilot deploys on ECS Fargate in your AWS account. We provide the Terraform modules and deployment support.",
+    q: "Does SparkPilot run in our AWS account?",
+    a: "Yes. SparkPilot is BYOC-oriented and keeps workload execution and data inside your AWS account boundary.",
   },
 ];
 
@@ -98,13 +87,14 @@ export default function PricingPage() {
       <LandingNav />
 
       <section className="landing-hero" style={{ paddingBottom: "clamp(28px, 4vw, 48px)" }}>
-        <div className="landing-hero-badge">Pricing</div>
+        <div className="landing-hero-badge">Plans and Scope</div>
         <h2 className="landing-hero-title">
-          Simple, transparent<br />
-          <span className="landing-hero-accent">pricing for every team</span>
+          Honest packaging for the <br />
+          <span className="landing-hero-accent">current product stage</span>
         </h2>
         <p className="landing-hero-sub">
-          Start free with self-hosted Community. Talk to us when you need production support, SLAs, or enterprise compliance.
+          This page reflects current reality: what is usable now, what is in limited validation, and what is not yet
+          a launch commitment.
         </p>
       </section>
 
@@ -112,7 +102,7 @@ export default function PricingPage() {
         <div className="pricing-grid">
           {TIERS.map((tier) => (
             <div key={tier.name} className={`pricing-card${tier.featured ? " pricing-card-featured" : ""}`}>
-              {tier.featured && <div className="pricing-badge">Most Popular</div>}
+              {tier.featured && <div className="pricing-badge">Current Recommended Path</div>}
               <div className="pricing-header">
                 <h3 className="pricing-name">{tier.name}</h3>
                 <div className="pricing-price">
@@ -130,10 +120,10 @@ export default function PricingPage() {
                 {tier.cta}
               </Link>
               <ul className="pricing-features">
-                {tier.features.map((f) => (
-                  <li key={f} className="pricing-feature">
-                    <span className="pricing-check" aria-hidden="true">✓</span>
-                    {f}
+                {tier.features.map((feature) => (
+                  <li key={feature} className="pricing-feature">
+                    <span className="pricing-check" aria-hidden="true">+</span>
+                    {feature}
                   </li>
                 ))}
               </ul>
@@ -145,7 +135,7 @@ export default function PricingPage() {
       <section className="landing-section">
         <div className="landing-section-header">
           <div className="landing-section-badge">FAQ</div>
-          <h2 className="landing-section-title">Common questions</h2>
+          <h2 className="landing-section-title">Scope clarity</h2>
         </div>
         <div className="faq-list">
           {FAQ.map((item) => (
@@ -158,13 +148,11 @@ export default function PricingPage() {
       </section>
 
       <section className="landing-cta">
-        <h2>Not sure which plan is right for you?</h2>
-        <p>Talk to us. We'll help you figure out the right setup for your team's size and AWS footprint.</p>
+        <h2>Need an evidence-backed pilot path?</h2>
+        <p>Start with the staged workflow and expand scope only after live validation in your environment.</p>
         <div className="landing-hero-actions">
-          <Link href="/contact" className="landing-btn landing-btn-primary">Talk to us</Link>
-          <Link href="https://github.com/JoshMcQ/SparkPilot" target="_blank" rel="noopener noreferrer" className="landing-btn landing-btn-secondary">
-            View docs
-          </Link>
+          <Link href="/getting-started" className="landing-btn landing-btn-primary">Open getting started</Link>
+          <Link href="/contact" className="landing-btn landing-btn-secondary">Talk to us</Link>
         </div>
       </section>
 
@@ -172,3 +160,4 @@ export default function PricingPage() {
     </div>
   );
 }
+

--- a/ui/app/why-not-diy/page.tsx
+++ b/ui/app/why-not-diy/page.tsx
@@ -5,57 +5,57 @@ import { LandingFooter } from "@/components/landing-footer";
 const COSTS = [
   {
     category: "IAM Complexity",
-    hours: "40–80 hrs initial setup",
-    recurring: "10–20 hrs/month",
+    hours: "40-80 hrs initial setup",
+    recurring: "10-20 hrs/month",
     description:
-      "Every team needs its own execution role, IRSA binding, trust policy, and namespace scoping. Wrong IAM → silent job failures, data leakage risk, or blocked dispatches. SparkPilot ships a validated IAM model (BYOC-Lite role, execution role trust, iam:PassRole) and checks it on every preflight.",
+      "Every team needs its own execution role, IRSA binding, trust policy, and namespace scoping. Wrong IAM -> silent job failures, data leakage risk, or blocked dispatches. SparkPilot ships a validated IAM model (BYOC-Lite role, execution role trust, iam:PassRole) and checks it on every preflight.",
   },
   {
     category: "Namespace Isolation",
-    hours: "8–16 hrs initial setup",
-    recurring: "2–4 hrs/month",
+    hours: "8-16 hrs initial setup",
+    recurring: "2-4 hrs/month",
     description:
       "Multi-tenant EKS requires ResourceQuota, LimitRange, and RBAC per namespace. Miss one and a runaway job can starve other teams. SparkPilot validates namespace-level isolation and prevents reserved-namespace collisions at onboarding time.",
   },
   {
     category: "Spot Instance Readiness",
-    hours: "6–12 hrs per cluster",
-    recurring: "2–5 hrs/month",
+    hours: "6-12 hrs per cluster",
+    recurring: "2-5 hrs/month",
     description:
       "Spot requires diversified node groups (3+ instance types), correct executor tolerations, and capacity-type selectors in your spark conf. Without all three, jobs land on on-demand or fail to schedule. SparkPilot validates spot capacity, diversification, and executor placement on every preflight.",
   },
   {
     category: "EMR Release Lifecycle",
-    hours: "4–8 hrs initial",
-    recurring: "3–6 hrs/month",
+    hours: "4-8 hrs initial",
+    recurring: "3-6 hrs/month",
     description:
-      "EMR releases reach end-of-life without warning. Running a deprecated release means no security patches and no AWS support. SparkPilot syncs 141+ EMR release records, tracks current/deprecated/EOL status, and warns you before dispatch if your label is out of date.",
+      "EMR releases reach end-of-life without warning. Running a deprecated release means no security patches and no AWS support. SparkPilot tracks release lifecycle status and can warn before dispatch when your configured label is out of date.",
   },
   {
     category: "Cost Visibility",
-    hours: "20–40 hrs to set up CUR pipeline",
-    recurring: "5–10 hrs/month",
+    hours: "20-40 hrs to set up CUR pipeline",
+    recurring: "5-10 hrs/month",
     description:
       "Without per-run cost tagging and CUR reconciliation, you can't answer 'which team spent $12k on Spark last month?' SparkPilot tags every run with a SparkPilot run ID, estimates cost at submission, and reconciles against your CUR via Athena for actual billing data.",
   },
   {
     category: "Policy Enforcement",
-    hours: "15–30 hrs to build",
-    recurring: "5–10 hrs/month",
+    hours: "15-30 hrs to build",
+    recurring: "5-10 hrs/month",
     description:
-      "Resource guards (max vCPU, max memory, max runtime, allowed release labels) need to be enforced at submission time, not discovered in a bill. SparkPilot ships a policy engine with hard-block (HTTP 422) and soft-warn enforcement — no custom admission webhook required.",
+      "Resource guards (max vCPU, max memory, max runtime, allowed release labels) need to be enforced at submission time, not discovered in a bill. SparkPilot ships a policy engine with hard-block (HTTP 422) and soft-warn enforcement - no custom admission webhook required.",
   },
   {
     category: "Upgrade Lifecycle",
-    hours: "20–40 hrs per major upgrade",
-    recurring: "10–20 hrs/quarter",
+    hours: "20-40 hrs per major upgrade",
+    recurring: "10-20 hrs/quarter",
     description:
       "Upgrading EMR release labels, Kubernetes versions, and Spark config parameters across multiple environments is a quarterly fire drill when done by hand. SparkPilot surfaces upgrade targets in the UI and validates compatibility in preflight before you change anything.",
   },
   {
     category: "Monitoring & Diagnostics",
-    hours: "15–25 hrs initial",
-    recurring: "3–8 hrs/month",
+    hours: "15-25 hrs initial",
+    recurring: "3-8 hrs/month",
     description:
       "CloudWatch log tailing, structured run diagnostics, and pattern-matching for spot interruptions, OOM events, and executor failures are non-trivial to build. SparkPilot ships structured diagnostics with categorized error patterns out of the box.",
   },
@@ -63,36 +63,36 @@ const COSTS = [
 
 const WHAT_SP_SHIPS = [
   {
-    title: "Preflight checks",
-    body: "20+ IAM, OIDC, quota, policy, release, and spot readiness checks run before every dispatch — not after the job fails.",
+    title: "Live now: Preflight checks",
+    body: "20+ IAM, OIDC, quota, policy, release, and spot readiness checks run before every dispatch - not after the job fails.",
   },
   {
-    title: "BYOC-Lite onboarding",
+    title: "Live now: BYOC-Lite onboarding",
     body: "Automated virtual cluster provisioning, trust policy management, and OIDC provider association in your account.",
   },
   {
-    title: "Policy engine",
-    body: "Global and scoped policies with hard-block (HTTP 422) or soft-warn enforcement. max_vcpu, max_memory_gb, max_run_seconds, allowed_release_labels, allowed_golden_paths, and more.",
+    title: "Limited validation: Policy engine",
+    body: "Policy CRUD and enforcement paths are implemented, with broader enterprise hardening and validation still in progress.",
   },
   {
-    title: "CUR reconciliation",
-    body: "Per-run cost tagging, estimated cost at submission, and Athena-backed reconciliation against your Cost and Usage Reports.",
+    title: "Limited validation: Cost reconciliation",
+    body: "Per-run cost tagging and CUR reconciliation paths exist, but proof depth is still environment-dependent.",
   },
   {
-    title: "EMR release lifecycle",
-    body: "141+ release records with current/deprecated/EOL status, Graviton support, and upgrade target tracking — synced from the AWS API.",
+    title: "Limited validation: EMR release lifecycle",
+    body: "Release lifecycle checks and warnings exist, but broad production validation across customer release matrices is still progressing.",
   },
   {
-    title: "Team budgets",
-    body: "Monthly budget caps per team with utilization tracking and soft-cap warnings before jobs run over budget.",
+    title: "Limited validation: Team budgets",
+    body: "Budget guardrail logic is implemented with warning and block behavior, with limited live validation so far.",
   },
   {
-    title: "Structured diagnostics",
+    title: "Live now: Structured diagnostics",
     body: "CloudWatch log analysis with pattern matching for spot interruptions, OOM, executor failures, and configuration errors.",
   },
   {
-    title: "YuniKorn queue management",
-    body: "Queue utilization checks and guaranteed vs max vCPU tracking for multi-tenant fair scheduling.",
+    title: "Coming soon: YuniKorn scheduling controls",
+    body: "Queue utilization hints exist, while fully proven multi-tenant YuniKorn workflow guarantees remain in progress.",
   },
 ];
 
@@ -109,7 +109,7 @@ export default function WhyNotDIYPage() {
           </h1>
           <p className="objection-hero-sub">
             You can. Platform teams have been doing it for years. Here is an honest accounting
-            of what that actually costs — and what you are giving up every month you are doing
+            of what that actually costs - and what you are giving up every month you are doing
             it by hand.
           </p>
         </section>
@@ -119,7 +119,7 @@ export default function WhyNotDIYPage() {
           <h2 className="objection-section-title">The real cost of DIY EMR on EKS</h2>
           <p className="objection-section-sub">
             These estimates are based on work we observed while building SparkPilot.
-            Your numbers will vary — but the categories won&apos;t.
+            Your numbers will vary - but the categories won't.
           </p>
           <div className="objection-cost-grid">
             {COSTS.map((c) => (
@@ -136,18 +136,17 @@ export default function WhyNotDIYPage() {
             ))}
           </div>
           <div className="objection-cost-total">
-            <strong>Total rough estimate:</strong> 130–250 hours to reach parity with SparkPilot&apos;s
-            current feature set. 40–80 hours of ongoing maintenance per month. That is a
-            half-time senior engineer every month — indefinitely.
+            <strong>Directional estimate only:</strong> these are planning heuristics, not guaranteed benchmarks.
+            Validate with your own team, compliance requirements, and workload profile before committing to a DIY path.
           </div>
         </section>
 
         {/* What SparkPilot ships */}
         <section className="objection-section objection-section-alt">
-          <h2 className="objection-section-title">What SparkPilot ships, validated on real AWS</h2>
+          <h2 className="objection-section-title">What SparkPilot ships today</h2>
           <p className="objection-section-sub">
-            Not roadmap features. Not checkbox items. Capabilities validated end-to-end with
-            real EMR virtual clusters, real EKS node groups, and real CloudWatch output.
+            Not roadmap placeholders. These are implemented product surfaces, with validation
+            depth varying by feature and runtime.
           </p>
           <div className="objection-ships-grid">
             {WHAT_SP_SHIPS.map((item) => (
@@ -170,7 +169,7 @@ export default function WhyNotDIYPage() {
             <li>You have a dedicated platform engineering team with 2+ engineers and Spark is their primary focus.</li>
             <li>You have unique IAM or network topology requirements that a multi-tenant control plane cannot accommodate.</li>
             <li>You run exclusively in a single team with no need for multi-tenant isolation, policy enforcement, or cost allocation.</li>
-            <li>You have a compliance requirement that prohibits any third-party software in your data plane — even if it never sees your data.</li>
+            <li>You have a compliance requirement that prohibits any third-party software in your data plane - even if it never sees your data.</li>
           </ul>
           <p className="objection-honest-note">
             If none of those apply, you are paying engineering salary to solve a problem that is
@@ -184,7 +183,7 @@ export default function WhyNotDIYPage() {
           <h2>Still want to evaluate?</h2>
           <p>
             We will walk you through the exact IAM model, preflight checks, and policy configuration
-            that SparkPilot ships. No pitch — just a technical deep-dive.
+            that SparkPilot ships. No pitch - just a technical deep-dive.
           </p>
           <div className="objection-cta-actions">
             <Link href="/contact" className="landing-btn landing-btn-primary">
@@ -200,3 +199,4 @@ export default function WhyNotDIYPage() {
     </>
   );
 }
+

--- a/ui/app/why-not-serverless/page.tsx
+++ b/ui/app/why-not-serverless/page.tsx
@@ -9,7 +9,7 @@ const TRADEOFFS = [
     description:
       "EMR Serverless spins up workers on demand for every application. You cannot pre-warm a set of workers that stay alive between jobs. For batch workloads running every 15 minutes, this is constant cold-start overhead.",
     sparkpilot:
-      "EMR on EKS with SparkPilot supports persistent managed node groups and Karpenter-based warm capacity. Workers can be reused across jobs within the same virtual cluster.",
+      "On the EMR on EKS path, SparkPilot can run with persistent node groups and warm capacity depending on your cluster configuration.",
   },
   {
     title: "Cold start latency",
@@ -17,7 +17,7 @@ const TRADEOFFS = [
     description:
       "Serverless cold starts range from 30 seconds to several minutes depending on worker size and availability. Interactive and near-real-time workloads cannot absorb this latency.",
     sparkpilot:
-      "With EKS-backed warm pools and Spot node groups, SparkPilot environments can achieve sub-10-second executor availability for pre-warmed capacity.",
+      "With EKS-backed warm capacity and tuned node groups, SparkPilot can reduce startup latency for repeated workloads.",
   },
   {
     title: "No Kubernetes scheduling control",
@@ -25,15 +25,15 @@ const TRADEOFFS = [
     description:
       "You cannot use Kubernetes node selectors, taints, tolerations, or pod affinity to control where workloads land. Serverless manages placement entirely. You cannot co-locate jobs with S3 Express One Zone endpoints or GPU nodes.",
     sparkpilot:
-      "Full Kubernetes scheduling control via spark conf. Spot selectors, GPU node affinity, S3 Express co-location, and Karpenter NodePool targeting are all supported.",
+      "SparkPilot passes Spark configuration to EMR on EKS runs, including Kubernetes selector and placement hints when configured.",
   },
   {
     title: "No YuniKorn fair scheduling",
     impact: "Medium",
     description:
-      "YuniKorn provides queue-based fair scheduling, guaranteed vCPU allocations per team, and preemption policies. None of these exist in Serverless — every application competes for capacity without SLA guarantees.",
+      "YuniKorn provides queue-based fair scheduling, guaranteed vCPU allocations per team, and preemption policies. None of these exist in Serverless - every application competes for capacity without SLA guarantees.",
     sparkpilot:
-      "SparkPilot exposes YuniKorn queue configuration per environment, validates queue utilization at preflight, and enforces guaranteed vs max vCPU bounds per team.",
+      "SparkPilot supports YuniKorn queue fields and preflight queue-capacity checks, but customer rollout validation is still limited.",
   },
   {
     title: "No cost allocation per team",
@@ -41,7 +41,7 @@ const TRADEOFFS = [
     description:
       "Serverless bills by application-level resource usage, but does not give you per-team or per-run cost attribution unless you build it yourself using resource tags and a CUR pipeline.",
     sparkpilot:
-      "SparkPilot tags every run with a run ID, estimates cost at submission, and reconciles actual cost per run from your CUR via Athena. Cost is attributed by team, environment, and job automatically.",
+      "SparkPilot tracks per-run usage and attribution fields, with deeper cost reconciliation depending on customer CUR setup and validation depth.",
   },
   {
     title: "No BYOC model",
@@ -49,7 +49,7 @@ const TRADEOFFS = [
     description:
       "EMR Serverless is a fully managed AWS service. Your job artifacts run in AWS-managed infrastructure. There is no way to ensure workers run inside your VPC, your subnets, or your security groups without complex VPC connector configuration.",
     sparkpilot:
-      "SparkPilot is BYOC-first. The control plane runs in your account, your VPC, your EKS cluster. Your data never leaves your perimeter. The BYOC-Lite role grants SparkPilot exactly the permissions it needs — nothing more.",
+      "SparkPilot is BYOC-first. The control plane runs in your account, your VPC, your EKS cluster. Your data never leaves your perimeter. The BYOC-Lite role grants SparkPilot exactly the permissions it needs - nothing more.",
   },
   {
     title: "No pre-dispatch policy enforcement",
@@ -57,7 +57,7 @@ const TRADEOFFS = [
     description:
       "Serverless will accept and start any job you submit. Resource limits, release label policies, and team budget caps are not enforced at submission time. You discover overages in the bill.",
     sparkpilot:
-      "SparkPilot's policy engine enforces max_vcpu, max_memory_gb, max_run_seconds, and allowed_release_labels before a single executor starts. Hard-block policies return HTTP 422 with the policy name in the error.",
+      "SparkPilot policy checks run at preflight, with policy maturity currently in limited-validation status.",
   },
   {
     title: "Limited Spark configuration surface",
@@ -83,7 +83,7 @@ const WHEN_SERVERLESS_WINS = [
   {
     scenario: "Very small teams",
     detail:
-      "Teams of 1–2 data engineers where the multi-tenant isolation, policy engine, and cost allocation overhead is not worth the setup.",
+      "Teams of 1-2 data engineers where the multi-tenant isolation, policy engine, and cost allocation overhead is not worth the setup.",
   },
   {
     scenario: "AWS Glue replacement",
@@ -94,12 +94,12 @@ const WHEN_SERVERLESS_WINS = [
 
 const COMPARE_ROWS = [
   { capability: "Persistent warm capacity", serverless: false, sp: true },
-  { capability: "Sub-10s executor availability", serverless: false, sp: true },
+  { capability: "Lower startup latency with warm capacity", serverless: false, sp: true },
   { capability: "Kubernetes scheduling control", serverless: false, sp: true },
-  { capability: "YuniKorn fair scheduling", serverless: false, sp: true },
+  { capability: "YuniKorn fair scheduling", serverless: false, sp: "partial" },
   { capability: "Per-run cost attribution", serverless: false, sp: true },
   { capability: "BYOC model (your VPC, your EKS)", serverless: false, sp: true },
-  { capability: "Pre-dispatch policy enforcement", serverless: false, sp: true },
+  { capability: "Pre-dispatch policy enforcement", serverless: false, sp: "partial" },
   { capability: "Spot instance management", serverless: "partial", sp: true },
   { capability: "Full Spark conf surface", serverless: false, sp: true },
   { capability: "Zero cluster management", serverless: true, sp: false },
@@ -108,8 +108,8 @@ const COMPARE_ROWS = [
 ];
 
 function Cell({ value }: { value: boolean | "partial" }) {
-  if (value === true) return <span className="objection-cell objection-cell-yes" aria-label="Yes">✓</span>;
-  if (value === false) return <span className="objection-cell objection-cell-no" aria-label="No">✗</span>;
+  if (value === true) return <span className="objection-cell objection-cell-yes" aria-label="Yes">Y</span>;
+  if (value === false) return <span className="objection-cell objection-cell-no" aria-label="No">N</span>;
   return <span className="objection-cell objection-cell-partial" aria-label="Partial">~</span>;
 }
 
@@ -126,7 +126,7 @@ export default function WhyNotServerlessPage() {
           </h1>
           <p className="objection-hero-sub">
             EMR Serverless is a legitimate option for some workloads. Here is an honest breakdown
-            of the tradeoffs — so you can make the right call for your team&apos;s actual requirements.
+            of the tradeoffs - so you can make the right call for your team's actual requirements.
           </p>
         </section>
 
@@ -164,7 +164,7 @@ export default function WhyNotServerlessPage() {
         <section className="objection-section objection-section-alt">
           <h2 className="objection-section-title">Tradeoff deep-dive</h2>
           <p className="objection-section-sub">
-            These are real constraints — not marketing FUD. Each one matters in specific
+            These are real constraints - not marketing FUD. Each one matters in specific
             production scenarios.
           </p>
           <div className="objection-tradeoff-list">
@@ -204,17 +204,15 @@ export default function WhyNotServerlessPage() {
 
         {/* SparkPilot also supports Serverless */}
         <section className="objection-section objection-section-highlight">
-          <h2 className="objection-section-title">SparkPilot also dispatches to EMR Serverless</h2>
+          <h2 className="objection-section-title">EMR Serverless path status</h2>
           <p>
-            SparkPilot is not an either/or choice. The same preflight pipeline, policy engine,
-            and cost tagging runs regardless of which execution engine you use. You can route
-            production batch workloads to EMR on EKS for latency and cost control, and route
-            ad-hoc or dev workloads to Serverless from the same control plane.
+            SparkPilot includes backend dispatch code for EMR Serverless, but the current launch scope is
+            batch-first on EMR on EKS. Treat Serverless as coming soon until complete end-to-end validation
+            and support workflows are in place.
           </p>
           <p>
-            The governance layer — preflight checks, policies, CUR reconciliation, audit trail —
-            applies to all engines. You get visibility and control over every job, regardless
-            of which AWS service runs it.
+            If your immediate priority is low-ops ad-hoc execution, EMR Serverless may still be the better short-term
+            choice while SparkPilot expands proven multi-engine parity.
           </p>
         </section>
 
@@ -239,3 +237,4 @@ export default function WhyNotServerlessPage() {
     </>
   );
 }
+

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -51,7 +51,7 @@ export async function isSessionActive(): Promise<boolean> {
   }
 }
 
-export function storeUserAccessToken(token: string): void {
+export async function storeUserAccessToken(token: string): Promise<void> {
   if (typeof window === "undefined") {
     return;
   }
@@ -60,7 +60,7 @@ export function storeUserAccessToken(token: string): void {
 
   // Store in HttpOnly cookie via session API (#58)
   if (value) {
-    fetch("/api/auth/session", {
+    await fetch("/api/auth/session", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ access_token: value }),
@@ -68,7 +68,7 @@ export function storeUserAccessToken(token: string): void {
       // Silent fallback — cookie will be missing, header auth still works
     });
   } else {
-    fetch("/api/auth/session", { method: "DELETE" }).catch(() => {});
+    await fetch("/api/auth/session", { method: "DELETE" }).catch(() => {});
   }
 
   // Keep localStorage for backward compat in dev mode only
@@ -510,6 +510,27 @@ export async function fetchQueueUtilization(environmentId: string): Promise<Queu
   }
   const payload = await response.json();
   return _asObject(payload, "Queue utilization fetch") as QueueUtilizationResponse;
+}
+
+export type KpiMetrics = {
+  preflight_outcome_rates: Record<string, unknown>;
+  dispatch_success_rate: Record<string, unknown>;
+  queue_to_running_latency: Record<string, unknown>;
+  budget_guardrail_triggers: Record<string, unknown>;
+  terminal_outcome_distribution: Record<string, unknown>;
+  jwks_refresh_stats: Record<string, unknown>;
+};
+
+export async function fetchKpiMetrics(): Promise<KpiMetrics> {
+  const response = await fetch(`${API_PREFIX}/v1/metrics/kpis`, {
+    cache: "no-store",
+    headers: _headers(false),
+  });
+  if (!response.ok) {
+    throw new Error(await _extractDetail(response, "Failed to load KPI metrics"));
+  }
+  const payload = await response.json();
+  return _asObject(payload, "KPI metrics fetch") as KpiMetrics;
 }
 
 export type RunSubmitRequest = {


### PR DESCRIPTION
﻿## Summary
- Reclassifies customer-facing product claims into explicit truth tiers: **Live now**, **Limited validation / beta**, and **Coming soon**
- Narrows launch messaging to the staged, batch-first path and removes over-claims on advanced surfaces
- Keeps strong prior backend/issue evidence respected while downgrading customer-facing positioning where workflow proof is still limited
- Fixes callback navigation to use full-page redirect after token exchange to avoid first-route session race
- Cleans up visible copy/encoding artifacts on updated pages

## Scope (this PR)
- `ui/app/page.tsx`
- `ui/app/pricing/page.tsx`
- `ui/app/getting-started/page.tsx`
- `ui/app/integrations/page.tsx`
- `ui/app/policies/page.tsx`
- `ui/app/why-not-diy/page.tsx`
- `ui/app/why-not-serverless/page.tsx`
- `ui/app/dashboard/page.tsx`
- `ui/app/auth/callback/page.tsx`

## Validation
- `npm --prefix ui run build` (pass)

## Why now
- Turns local-only truth cleanup into a real deployable change so staging product surface matches what is honestly proven today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KPI Snapshot on the dashboard showing pass rate, dispatch success, and JWKS refresh stats.
  * Product Truth Map on the landing page categorizing capabilities as Live Now, Limited Validation, or Coming Soon.

* **UI/UX**
  * Landing, pricing, and dashboard copy/content reorganized for clearer scope and CTAs.
  * Pricing and feature lists updated for plan/feature clarity.

* **Bug Fixes**
  * Improved OIDC callback flow to ensure consistent post-sign-in navigation.

* **Documentation**
  * Updated onboarding, integrations, and policy wording to reflect current launch scope and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->