### PR TITLE
feat(ci): enforce non-prod cost guardrails and lean deploy lanes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -178,11 +178,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy preflight — validate required secrets
+      - name: Deploy preflight - validate required secrets
         id: preflight
         shell: bash
         env:
           DEPLOY_ENV: dev
+          DEPLOY_ENABLED: ${{ vars.DEV_DEPLOY_ENABLED || 'false' }}
           ROLE_ARN: ${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}
           TF_STATE_BUCKET: ${{ secrets.DEV_TF_STATE_BUCKET }}
           TF_LOCK_TABLE: ${{ secrets.DEV_TF_LOCK_TABLE }}
@@ -193,6 +194,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.DEV_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.DEV_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.DEV_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.DEV_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.DEV_WORKER_DESIRED_COUNT || '0' }}
+          TF_VAR_ui_desired_count: ${{ vars.DEV_UI_DESIRED_COUNT || '0' }}
+          TF_VAR_db_instance_class: ${{ vars.DEV_DB_INSTANCE_CLASS || 'db.t4g.micro' }}
           EMR_EXECUTION_ROLE_ARN: ${{ secrets.DEV_EMR_EXECUTION_ROLE_ARN }}
         run: bash scripts/ci/deploy_preflight.sh
 
@@ -301,6 +306,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.DEV_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.DEV_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.DEV_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.DEV_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.DEV_WORKER_DESIRED_COUNT || '0' }}
+          TF_VAR_ui_desired_count: ${{ vars.DEV_UI_DESIRED_COUNT || '0' }}
+          TF_VAR_db_instance_class: ${{ vars.DEV_DB_INSTANCE_CLASS || 'db.t4g.micro' }}
           DRY_RUN_MODE: ${{ vars.DEV_DRY_RUN_MODE || 'false' }}
           ENABLE_FULL_BYOC_MODE: ${{ vars.DEV_ENABLE_FULL_BYOC_MODE || 'false' }}
           ALLOW_UNSAFE_RDS_CONFIGURATION: ${{ vars.DEV_ALLOW_UNSAFE_RDS_CONFIGURATION || 'false' }}
@@ -345,11 +354,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy preflight — validate required secrets
+      - name: Deploy preflight - validate required secrets
         id: preflight
         shell: bash
         env:
           DEPLOY_ENV: staging
+          DEPLOY_ENABLED: ${{ vars.STAGING_DEPLOY_ENABLED || 'true' }}
           ROLE_ARN: ${{ secrets.AWS_STAGING_DEPLOY_ROLE_ARN }}
           TF_STATE_BUCKET: ${{ secrets.STAGING_TF_STATE_BUCKET }}
           TF_LOCK_TABLE: ${{ secrets.STAGING_TF_LOCK_TABLE }}
@@ -360,6 +370,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.STAGING_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.STAGING_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.STAGING_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.STAGING_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.STAGING_WORKER_DESIRED_COUNT || '1' }}
+          TF_VAR_ui_desired_count: ${{ vars.STAGING_UI_DESIRED_COUNT || '1' }}
+          TF_VAR_db_instance_class: ${{ vars.STAGING_DB_INSTANCE_CLASS || 'db.t4g.small' }}
           EMR_EXECUTION_ROLE_ARN: ${{ secrets.STAGING_EMR_EXECUTION_ROLE_ARN }}
         run: bash scripts/ci/deploy_preflight.sh
 
@@ -468,6 +482,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.STAGING_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.STAGING_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.STAGING_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.STAGING_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.STAGING_WORKER_DESIRED_COUNT || '1' }}
+          TF_VAR_ui_desired_count: ${{ vars.STAGING_UI_DESIRED_COUNT || '1' }}
+          TF_VAR_db_instance_class: ${{ vars.STAGING_DB_INSTANCE_CLASS || 'db.t4g.small' }}
           TF_VAR_manage_vpc_endpoints: ${{ vars.STAGING_MANAGE_VPC_ENDPOINTS || 'false' }}
           DRY_RUN_MODE: ${{ vars.STAGING_DRY_RUN_MODE || 'false' }}
           ENABLE_FULL_BYOC_MODE: ${{ vars.STAGING_ENABLE_FULL_BYOC_MODE || 'false' }}
@@ -514,11 +532,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy preflight — validate required secrets
+      - name: Deploy preflight - validate required secrets
         id: preflight
         shell: bash
         env:
           DEPLOY_ENV: prod
+          DEPLOY_ENABLED: ${{ vars.PROD_DEPLOY_ENABLED || 'false' }}
           ROLE_ARN: ${{ secrets.AWS_PROD_DEPLOY_ROLE_ARN }}
           TF_STATE_BUCKET: ${{ secrets.PROD_TF_STATE_BUCKET }}
           TF_LOCK_TABLE: ${{ secrets.PROD_TF_LOCK_TABLE }}
@@ -529,6 +548,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.PROD_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.PROD_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.PROD_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.PROD_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.PROD_WORKER_DESIRED_COUNT || '1' }}
+          TF_VAR_ui_desired_count: ${{ vars.PROD_UI_DESIRED_COUNT || '1' }}
+          TF_VAR_db_instance_class: ${{ vars.PROD_DB_INSTANCE_CLASS || 'db.t4g.medium' }}
           EMR_EXECUTION_ROLE_ARN: ${{ secrets.PROD_EMR_EXECUTION_ROLE_ARN }}
         run: bash scripts/ci/deploy_preflight.sh
 
@@ -637,6 +660,10 @@ jobs:
           OIDC_AUDIENCE: ${{ secrets.PROD_OIDC_AUDIENCE }}
           OIDC_JWKS_URI: ${{ secrets.PROD_OIDC_JWKS_URI }}
           BOOTSTRAP_SECRET: ${{ secrets.PROD_BOOTSTRAP_SECRET }}
+          TF_VAR_api_desired_count: ${{ vars.PROD_API_DESIRED_COUNT || '1' }}
+          TF_VAR_worker_desired_count: ${{ vars.PROD_WORKER_DESIRED_COUNT || '1' }}
+          TF_VAR_ui_desired_count: ${{ vars.PROD_UI_DESIRED_COUNT || '1' }}
+          TF_VAR_db_instance_class: ${{ vars.PROD_DB_INSTANCE_CLASS || 'db.t4g.medium' }}
           TF_VAR_manage_vpc_endpoints: ${{ vars.PROD_MANAGE_VPC_ENDPOINTS || 'false' }}
           DRY_RUN_MODE: ${{ vars.PROD_DRY_RUN_MODE || 'false' }}
           ENABLE_FULL_BYOC_MODE: ${{ vars.PROD_ENABLE_FULL_BYOC_MODE || 'false' }}
@@ -673,3 +700,4 @@ jobs:
           SMOKE_MAX_ATTEMPTS: "40"
           SMOKE_SLEEP_SECONDS: "5"
         run: bash scripts/smoke/control_plane_api.sh
+

--- a/.github/workflows/nonprod-cost-guardrails.yml
+++ b/.github/workflows/nonprod-cost-guardrails.yml
@@ -1,0 +1,114 @@
+name: nonprod-cost-guardrails
+
+on:
+  schedule:
+    - cron: "20 5 * * *"
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: "Environment to scale down"
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - staging
+      stop_rds:
+        description: "Stop RDS instance in target environment"
+        required: true
+        default: false
+        type: boolean
+      dry_run:
+        description: "Print actions without applying changes"
+        required: true
+        default: false
+        type: boolean
+
+env:
+  AWS_REGION: us-east-1
+
+jobs:
+  nightly-dev-scale-down:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Gate - dev deploy role configured
+        id: gate
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}" ]; then
+            echo "INFO: skipping nightly dev scale-down; AWS_DEV_DEPLOY_ROLE_ARN is not configured."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.gate.outputs.skip != 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Scale down dev non-prod footprint
+        if: steps.gate.outputs.skip != 'true'
+        shell: bash
+        env:
+          SPARKPILOT_ENVIRONMENT: dev
+          AWS_REGION: ${{ env.AWS_REGION }}
+          SCALE_ECS: "true"
+          STOP_RDS: "true"
+          DRY_RUN: "false"
+        run: bash scripts/ops/scale_nonprod_idle.sh
+
+  manual-dev-scale-down:
+    if: github.event_name == 'workflow_dispatch' && inputs.target_environment == 'dev'
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEV_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Manual scale down (dev)
+        shell: bash
+        env:
+          SPARKPILOT_ENVIRONMENT: dev
+          AWS_REGION: ${{ env.AWS_REGION }}
+          SCALE_ECS: "true"
+          STOP_RDS: ${{ inputs.stop_rds && 'true' || 'false' }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+        run: bash scripts/ops/scale_nonprod_idle.sh
+
+  manual-staging-scale-down:
+    if: github.event_name == 'workflow_dispatch' && inputs.target_environment == 'staging'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_STAGING_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Manual scale down (staging)
+        shell: bash
+        env:
+          SPARKPILOT_ENVIRONMENT: staging
+          AWS_REGION: ${{ env.AWS_REGION }}
+          SCALE_ECS: "true"
+          STOP_RDS: ${{ inputs.stop_rds && 'true' || 'false' }}
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+        run: bash scripts/ops/scale_nonprod_idle.sh

--- a/scripts/ci/deploy_preflight.sh
+++ b/scripts/ci/deploy_preflight.sh
@@ -1,41 +1,64 @@
 #!/usr/bin/env bash
-# deploy_preflight.sh — validate required deploy secrets before AWS auth.
+# deploy_preflight.sh - validate deploy gates/secrets before AWS auth.
 #
 # Environment variables expected (all injected from GHA secrets/vars):
-#   DEPLOY_ENV          — lowercase env name: dev | staging | prod
-#   ROLE_ARN            — AWS deploy role ARN (AWS_{ENV}_DEPLOY_ROLE_ARN)
-#   TF_STATE_BUCKET     — Terraform state S3 bucket
-#   TF_LOCK_TABLE       — Terraform DynamoDB lock table
-#   VPC_ID              — VPC ID for the environment
-#   PRIVATE_SUBNET_IDS_JSON — JSON array of private subnet IDs
-#   DB_PASSWORD         — RDS database password
-#   OIDC_ISSUER         — OIDC issuer URL
-#   OIDC_AUDIENCE       — OIDC audience
-#   OIDC_JWKS_URI       — OIDC JWKS URI
-#   BOOTSTRAP_SECRET    — API bootstrap secret
-#   EMR_EXECUTION_ROLE_ARN — EMR execution role ARN
+#   DEPLOY_ENV              - lowercase env name: dev | staging | prod
+#   DEPLOY_ENABLED          - optional gate. true enables deploy; false skips job.
+#   ROLE_ARN                - AWS deploy role ARN (AWS_{ENV}_DEPLOY_ROLE_ARN)
+#   TF_STATE_BUCKET         - Terraform state S3 bucket
+#   TF_LOCK_TABLE           - Terraform DynamoDB lock table
+#   VPC_ID                  - VPC ID for the environment
+#   PRIVATE_SUBNET_IDS_JSON - JSON array of private subnet IDs
+#   DB_PASSWORD             - RDS database password
+#   OIDC_ISSUER             - OIDC issuer URL
+#   OIDC_AUDIENCE           - OIDC audience
+#   OIDC_JWKS_URI           - OIDC JWKS URI
+#   BOOTSTRAP_SECRET        - API bootstrap secret
+#   EMR_EXECUTION_ROLE_ARN  - EMR execution role ARN
 #
 # Outputs (via GITHUB_OUTPUT):
-#   skip=true   — role ARN not set; environment not configured; job should skip remaining steps
-#   skip=false  — all required secrets present; proceed with deploy
+#   skip=true   - deploy disabled, role missing, or environment not configured
+#   skip=false  - all required gates/secrets present; proceed with deploy
 #
 # Exit codes:
-#   0  — skip=true (not configured) or skip=false (all good)
-#   1  — role ARN is set but one or more other required secrets are missing (actionable error)
+#   0 - skip=true (not configured/disabled) or skip=false (all good)
+#   1 - deploy is enabled and one or more required secrets are missing
 
 set -euo pipefail
 
-ENV_UPPER="${DEPLOY_ENV^^}"
+normalize_bool() {
+  local raw="${1:-}"
+  raw="$(echo "${raw}" | tr '[:upper:]' '[:lower:]' | xargs)"
+  case "${raw}" in
+    true|1|yes|y|on) echo "true" ;;
+    false|0|no|n|off|"") echo "false" ;;
+    *)
+      echo "::error::Invalid boolean value '${1}' for DEPLOY_ENABLED. Use true/false." >&2
+      exit 1
+      ;;
+  esac
+}
 
-# ── Gate 1: Is this environment configured at all? ──────────────────────────
+ENV_UPPER="${DEPLOY_ENV^^}"
+DEPLOY_ENABLED_NORMALIZED="$(normalize_bool "${DEPLOY_ENABLED:-true}")"
+
+# Gate 0: explicit deploy lane switch (cost control / freeze switch)
+if [[ "${DEPLOY_ENABLED_NORMALIZED}" != "true" ]]; then
+  echo "INFO: ${DEPLOY_ENV} deploy skipped - DEPLOY_ENABLED is false."
+  echo "      Set ${ENV_UPPER}_DEPLOY_ENABLED=true (GitHub environment variable) to re-enable this lane."
+  echo "skip=true" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+# Gate 1: Is this environment configured at all?
 if [ -z "${ROLE_ARN:-}" ]; then
-  echo "INFO: ${DEPLOY_ENV} deploy skipped — AWS_${ENV_UPPER}_DEPLOY_ROLE_ARN is not set."
+  echo "INFO: ${DEPLOY_ENV} deploy skipped - AWS_${ENV_UPPER}_DEPLOY_ROLE_ARN is not set."
   echo "      Configure this secret in the '${DEPLOY_ENV}' GitHub environment to enable ${DEPLOY_ENV} deploys."
   echo "skip=true" >> "${GITHUB_OUTPUT}"
   exit 0
 fi
 
-# ── Gate 2: Role ARN is present — validate all other required secrets ────────
+# Gate 2: Role ARN is present - validate all other required secrets
 declare -a MISSING=()
 
 [ -z "${TF_STATE_BUCKET:-}" ]         && MISSING+=("${ENV_UPPER}_TF_STATE_BUCKET")
@@ -55,7 +78,7 @@ fi
 [ -z "${EMR_EXECUTION_ROLE_ARN:-}" ]  && MISSING+=("${ENV_UPPER}_EMR_EXECUTION_ROLE_ARN")
 
 if [ "${#MISSING[@]}" -gt 0 ]; then
-  echo "::error::${DEPLOY_ENV} deploy preflight FAILED — role ARN is set but ${#MISSING[@]} required secret(s) are missing:"
+  echo "::error::${DEPLOY_ENV} deploy preflight FAILED - role ARN is set but ${#MISSING[@]} required secret(s) are missing:"
   for key in "${MISSING[@]}"; do
     echo "  missing: ${key}"
   done
@@ -65,4 +88,4 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
 fi
 
 echo "skip=false" >> "${GITHUB_OUTPUT}"
-echo "INFO: ${DEPLOY_ENV} deploy preflight passed — all required secrets present."
+echo "INFO: ${DEPLOY_ENV} deploy preflight passed - all required secrets present."

--- a/scripts/ops/scale_nonprod_idle.sh
+++ b/scripts/ops/scale_nonprod_idle.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+normalize_bool() {
+  local raw="${1:-}"
+  raw="$(echo "${raw}" | tr '[:upper:]' '[:lower:]' | xargs)"
+  case "${raw}" in
+    true|1|yes|y|on) echo "true" ;;
+    false|0|no|n|off|"") echo "false" ;;
+    *)
+      echo "ERROR: invalid boolean value '${1}'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+SPARKPILOT_ENVIRONMENT="$(echo "${SPARKPILOT_ENVIRONMENT:-dev}" | xargs)"
+AWS_REGION="$(echo "${AWS_REGION:-us-east-1}" | xargs)"
+ECS_CLUSTER_NAME="$(echo "${ECS_CLUSTER_NAME:-sparkpilot-${SPARKPILOT_ENVIRONMENT}-control-plane}" | xargs)"
+RDS_INSTANCE_IDENTIFIER="$(echo "${RDS_INSTANCE_IDENTIFIER:-sparkpilot-${SPARKPILOT_ENVIRONMENT}-postgres}" | xargs)"
+
+SCALE_ECS="$(normalize_bool "${SCALE_ECS:-true}")"
+STOP_RDS="$(normalize_bool "${STOP_RDS:-true}")"
+DRY_RUN="$(normalize_bool "${DRY_RUN:-false}")"
+
+run_cmd() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY_RUN: $*"
+  else
+    eval "$*"
+  fi
+}
+
+echo "Environment: ${SPARKPILOT_ENVIRONMENT}"
+echo "Region: ${AWS_REGION}"
+echo "ECS cluster target: ${ECS_CLUSTER_NAME}"
+echo "RDS target: ${RDS_INSTANCE_IDENTIFIER}"
+echo "Scale ECS: ${SCALE_ECS}, Stop RDS: ${STOP_RDS}, Dry run: ${DRY_RUN}"
+
+if [[ "${SCALE_ECS}" == "true" ]]; then
+  cluster_status="$(aws ecs describe-clusters \
+    --clusters "${ECS_CLUSTER_NAME}" \
+    --region "${AWS_REGION}" \
+    --query 'clusters[0].status' \
+    --output text 2>/dev/null || true)"
+
+  if [[ -z "${cluster_status}" || "${cluster_status}" == "None" ]]; then
+    echo "INFO: ECS cluster not found: ${ECS_CLUSTER_NAME}"
+  else
+    services="$(aws ecs list-services \
+      --cluster "${ECS_CLUSTER_NAME}" \
+      --region "${AWS_REGION}" \
+      --query 'serviceArns' \
+      --output text 2>/dev/null || true)"
+
+    if [[ -z "${services}" || "${services}" == "None" ]]; then
+      echo "INFO: no ECS services found in ${ECS_CLUSTER_NAME}"
+    else
+      for service_arn in ${services}; do
+        service_name="${service_arn##*/}"
+        desired_count="$(aws ecs describe-services \
+          --cluster "${ECS_CLUSTER_NAME}" \
+          --services "${service_name}" \
+          --region "${AWS_REGION}" \
+          --query 'services[0].desiredCount' \
+          --output text 2>/dev/null || echo 0)"
+
+        if [[ "${desired_count}" != "0" ]]; then
+          echo "Scaling ECS service to 0: ${service_name} (was ${desired_count})"
+          run_cmd "aws ecs update-service --cluster '${ECS_CLUSTER_NAME}' --service '${service_name}' --desired-count 0 --region '${AWS_REGION}' >/dev/null"
+        else
+          echo "ECS service already at 0: ${service_name}"
+        fi
+      done
+    fi
+  fi
+fi
+
+if [[ "${STOP_RDS}" == "true" ]]; then
+  db_status="$(aws rds describe-db-instances \
+    --db-instance-identifier "${RDS_INSTANCE_IDENTIFIER}" \
+    --region "${AWS_REGION}" \
+    --query 'DBInstances[0].DBInstanceStatus' \
+    --output text 2>/dev/null || true)"
+
+  case "${db_status}" in
+    available)
+      echo "Stopping RDS instance: ${RDS_INSTANCE_IDENTIFIER}"
+      run_cmd "aws rds stop-db-instance --db-instance-identifier '${RDS_INSTANCE_IDENTIFIER}' --region '${AWS_REGION}' >/dev/null"
+      ;;
+    stopped)
+      echo "RDS already stopped: ${RDS_INSTANCE_IDENTIFIER}"
+      ;;
+    ""|None)
+      echo "INFO: RDS instance not found: ${RDS_INSTANCE_IDENTIFIER}"
+      ;;
+    *)
+      echo "INFO: RDS instance ${RDS_INSTANCE_IDENTIFIER} in status '${db_status}' - no stop action taken."
+      ;;
+  esac
+fi
+
+echo "Non-prod scale-down routine completed."


### PR DESCRIPTION
﻿## Summary
- Adds explicit per-environment deploy lane gate (`DEPLOY_ENABLED`) in deploy preflight so environments can be disabled without removing secrets
- Sets safer pre-revenue lane defaults in CI:
  - `DEV_DEPLOY_ENABLED` defaults to `false`
  - `STAGING_DEPLOY_ENABLED` defaults to `true`
  - `PROD_DEPLOY_ENABLED` defaults to `false`
- Adds lean Terraform defaults in CI env wiring:
  - dev defaults: worker=0, ui=0, db class `db.t4g.micro`
  - staging defaults: db class `db.t4g.small`
  - prod defaults stay standard (`db.t4g.medium`, desired counts 1)
- Adds scheduled and manual non-prod scale-down workflow (`nonprod-cost-guardrails.yml`)
- Adds `scripts/ops/scale_nonprod_idle.sh` to scale ECS services to 0 and optionally stop RDS for dev/staging

## Why
- Prevents automatic dev/prod deploy churn from every merge
- Reduces always-on non-prod baseline cost while preserving staging as the primary batch-first validation path
- Adds concrete operational guardrails rather than recommendation-only cost guidance

## Validation
- `bash -n scripts/ci/deploy_preflight.sh`
- `bash -n scripts/ops/scale_nonprod_idle.sh`
- YAML parse check for both workflow files via `yaml.safe_load`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with deployment gating mechanism via `DEPLOY_ENABLED` variable, allowing conditional deployment control across dev/staging/production stages.
  * Introduced new cost guardrails automation workflow for non-production environments with scheduled and manual triggers to scale down resources.
  * Added infrastructure scaling script supporting ECS service and RDS instance management with dry-run capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->