### PR TITLE
fix(ci): add id-token permission to nonprod guardrail workflow

### DIFF
--- a/.github/workflows/nonprod-cost-guardrails.yml
+++ b/.github/workflows/nonprod-cost-guardrails.yml
@@ -24,6 +24,10 @@ on:
         default: false
         type: boolean
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   AWS_REGION: us-east-1
 


### PR DESCRIPTION
Adds required \id-token: write\ permission so \ws-actions/configure-aws-credentials@v4\ can assume deploy roles via OIDC in \
onprod-cost-guardrails.yml\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve security posture by establishing explicit permission scoping for workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->