### PR TITLE
fix(ops): detect actual ECS cluster names in nonprod scale-down guardrail

### DIFF
--- a/scripts/ops/scale_nonprod_idle.sh
+++ b/scripts/ops/scale_nonprod_idle.sh
@@ -16,7 +16,7 @@ normalize_bool() {
 
 SPARKPILOT_ENVIRONMENT="$(echo "${SPARKPILOT_ENVIRONMENT:-dev}" | xargs)"
 AWS_REGION="$(echo "${AWS_REGION:-us-east-1}" | xargs)"
-ECS_CLUSTER_NAME="$(echo "${ECS_CLUSTER_NAME:-sparkpilot-${SPARKPILOT_ENVIRONMENT}-control-plane}" | xargs)"
+ECS_CLUSTER_NAME_OVERRIDE="$(echo "${ECS_CLUSTER_NAME:-}" | xargs)"
 RDS_INSTANCE_IDENTIFIER="$(echo "${RDS_INSTANCE_IDENTIFIER:-sparkpilot-${SPARKPILOT_ENVIRONMENT}-postgres}" | xargs)"
 
 SCALE_ECS="$(normalize_bool "${SCALE_ECS:-true}")"
@@ -31,21 +31,60 @@ run_cmd() {
   fi
 }
 
+resolve_ecs_cluster_name() {
+  local -a candidates=()
+  local candidate=""
+  local status=""
+
+  if [[ -n "${ECS_CLUSTER_NAME_OVERRIDE}" ]]; then
+    candidates=("${ECS_CLUSTER_NAME_OVERRIDE}")
+  else
+    # Support both historical and current naming patterns.
+    candidates=(
+      "sparkpilot-${SPARKPILOT_ENVIRONMENT}-ecs"
+      "sparkpilot-${SPARKPILOT_ENVIRONMENT}-control-plane"
+    )
+  fi
+
+  for candidate in "${candidates[@]}"; do
+    status="$(aws ecs describe-clusters \
+      --clusters "${candidate}" \
+      --region "${AWS_REGION}" \
+      --query 'clusters[0].status' \
+      --output text 2>/dev/null || true)"
+    if [[ -n "${status}" && "${status}" != "None" ]]; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+
+  echo ""
+  return 1
+}
+
+ECS_CLUSTER_NAME="$(resolve_ecs_cluster_name || true)"
+
 echo "Environment: ${SPARKPILOT_ENVIRONMENT}"
 echo "Region: ${AWS_REGION}"
-echo "ECS cluster target: ${ECS_CLUSTER_NAME}"
+if [[ -n "${ECS_CLUSTER_NAME}" ]]; then
+  echo "ECS cluster target: ${ECS_CLUSTER_NAME}"
+else
+  if [[ -n "${ECS_CLUSTER_NAME_OVERRIDE}" ]]; then
+    echo "ECS cluster target: ${ECS_CLUSTER_NAME_OVERRIDE} (not found)"
+  else
+    echo "ECS cluster target: sparkpilot-${SPARKPILOT_ENVIRONMENT}-ecs|sparkpilot-${SPARKPILOT_ENVIRONMENT}-control-plane (not found)"
+  fi
+fi
 echo "RDS target: ${RDS_INSTANCE_IDENTIFIER}"
 echo "Scale ECS: ${SCALE_ECS}, Stop RDS: ${STOP_RDS}, Dry run: ${DRY_RUN}"
 
 if [[ "${SCALE_ECS}" == "true" ]]; then
-  cluster_status="$(aws ecs describe-clusters \
-    --clusters "${ECS_CLUSTER_NAME}" \
-    --region "${AWS_REGION}" \
-    --query 'clusters[0].status' \
-    --output text 2>/dev/null || true)"
-
-  if [[ -z "${cluster_status}" || "${cluster_status}" == "None" ]]; then
-    echo "INFO: ECS cluster not found: ${ECS_CLUSTER_NAME}"
+  if [[ -z "${ECS_CLUSTER_NAME}" ]]; then
+    if [[ -n "${ECS_CLUSTER_NAME_OVERRIDE}" ]]; then
+      echo "INFO: ECS cluster not found: ${ECS_CLUSTER_NAME_OVERRIDE}"
+    else
+      echo "INFO: ECS cluster not found for environment '${SPARKPILOT_ENVIRONMENT}'"
+    fi
   else
     services="$(aws ecs list-services \
       --cluster "${ECS_CLUSTER_NAME}" \


### PR DESCRIPTION
## Summary
- Fixes scripts/ops/scale_nonprod_idle.sh cluster discovery to handle current ECS naming (sparkpilot-<env>-ecs) and fallback to historical -control-plane
- Keeps explicit ECS_CLUSTER_NAME override support
- Prevents false-success scale-down runs where the script could not find clusters and therefore never scaled services

## Why
The new non-prod guardrail workflow succeeded but dev ECS services remained at desired=1 because the script targeted a non-existent cluster name.

## Validation
- ash -n scripts/ops/scale_nonprod_idle.sh
- manual re-run of nonprod-cost-guardrails after merge (dev target)
