### PR TITLE
feat(cost): staging dormancy schedule + allow api desired_count=0

### DIFF
--- a/.github/workflows/nonprod-cost-guardrails.yml
+++ b/.github/workflows/nonprod-cost-guardrails.yml
@@ -69,6 +69,57 @@ jobs:
           DRY_RUN: "false"
         run: bash scripts/ops/scale_nonprod_idle.sh
 
+  nightly-staging-scale-down:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Gate - staging nightly scale-down enabled
+        id: gate_enabled
+        shell: bash
+        env:
+          STAGING_NIGHTLY_SCALE_DOWN_ENABLED: ${{ vars.STAGING_NIGHTLY_SCALE_DOWN_ENABLED || 'false' }}
+        run: |
+          if [ "${STAGING_NIGHTLY_SCALE_DOWN_ENABLED}" != "true" ]; then
+            echo "INFO: skipping nightly staging scale-down; STAGING_NIGHTLY_SCALE_DOWN_ENABLED is not true."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate - staging deploy role configured
+        id: gate_role
+        if: steps.gate_enabled.outputs.skip != 'true'
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.AWS_STAGING_DEPLOY_ROLE_ARN }}" ]; then
+            echo "INFO: skipping nightly staging scale-down; AWS_STAGING_DEPLOY_ROLE_ARN is not configured."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        if: steps.gate_enabled.outputs.skip != 'true' && steps.gate_role.outputs.skip != 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_STAGING_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Scale down staging non-prod footprint
+        if: steps.gate_enabled.outputs.skip != 'true' && steps.gate_role.outputs.skip != 'true'
+        shell: bash
+        env:
+          SPARKPILOT_ENVIRONMENT: staging
+          AWS_REGION: ${{ env.AWS_REGION }}
+          SCALE_ECS: "true"
+          STOP_RDS: "true"
+          DRY_RUN: "false"
+        run: bash scripts/ops/scale_nonprod_idle.sh
+
   manual-dev-scale-down:
     if: github.event_name == 'workflow_dispatch' && inputs.target_environment == 'dev'
     runs-on: ubuntu-latest

--- a/infra/terraform/control-plane/variables.tf
+++ b/infra/terraform/control-plane/variables.tf
@@ -216,8 +216,8 @@ variable "api_desired_count" {
   description = "Desired number of API tasks."
   default     = 1
   validation {
-    condition     = var.api_desired_count >= 1
-    error_message = "api_desired_count must be at least 1."
+    condition     = var.api_desired_count >= 0
+    error_message = "api_desired_count must be zero or greater."
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds optional nightly staging scale-down job in 
onprod-cost-guardrails (gated by STAGING_NIGHTLY_SCALE_DOWN_ENABLED)
- Keeps staging dormancy opt-in so we can enable it post-prod cutover without workflow edits
- Allows pi_desired_count=0 in control-plane Terraform to support true dormant non-prod profiles via configuration

## Why
- Launch mode needs strict cost discipline: dev off by default, staging dormant by policy after prod activation
- Existing Terraform validation required API >= 1, which prevented clean config-driven dormant profiles

## Validation
- 	erraform -chdir=infra/terraform/control-plane validate
- workflow syntax reviewed in CI checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated nightly resource scaling for staging environments to optimize operational costs.

* **Chores**
  * Updated configuration validation to support scaling down API instances to zero, enabling greater flexibility in resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->