### PR TITLE
feat(ui): enterprise copy rewrite + staging direct API prefix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -283,6 +283,7 @@ jobs:
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ secrets.DEV_OIDC_CLIENT_ID }}
             NEXT_PUBLIC_OIDC_REDIRECT_URI=${{ vars.DEV_UI_APP_BASE_URL }}/auth/callback
             NEXT_PUBLIC_OIDC_AUDIENCE=sparkpilot-api
+            NEXT_PUBLIC_SPARKPILOT_API_PREFIX=${{ vars.DEV_SPARKPILOT_API_PREFIX || '/api/sparkpilot' }}
             NEXT_PUBLIC_COGNITO_IDENTITY_PROVIDER=${{ vars.DEV_COGNITO_IDENTITY_PROVIDER || '' }}
 
       - name: Terraform deploy (dev)
@@ -459,6 +460,7 @@ jobs:
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ secrets.STAGING_OIDC_CLIENT_ID }}
             NEXT_PUBLIC_OIDC_REDIRECT_URI=${{ vars.STAGING_UI_APP_BASE_URL }}/auth/callback
             NEXT_PUBLIC_OIDC_AUDIENCE=sparkpilot-api
+            NEXT_PUBLIC_SPARKPILOT_API_PREFIX=${{ vars.STAGING_SPARKPILOT_API_PREFIX || '/api/sparkpilot' }}
             NEXT_PUBLIC_COGNITO_IDENTITY_PROVIDER=${{ vars.STAGING_COGNITO_IDENTITY_PROVIDER || '' }}
 
       - name: Terraform deploy (staging)
@@ -637,6 +639,7 @@ jobs:
             NEXT_PUBLIC_OIDC_CLIENT_ID=${{ secrets.PROD_OIDC_CLIENT_ID }}
             NEXT_PUBLIC_OIDC_REDIRECT_URI=${{ vars.PROD_UI_APP_BASE_URL }}/auth/callback
             NEXT_PUBLIC_OIDC_AUDIENCE=sparkpilot-api
+            NEXT_PUBLIC_SPARKPILOT_API_PREFIX=${{ vars.PROD_SPARKPILOT_API_PREFIX || '/api/sparkpilot' }}
             NEXT_PUBLIC_COGNITO_IDENTITY_PROVIDER=${{ vars.PROD_COGNITO_IDENTITY_PROVIDER || '' }}
 
       - name: Terraform deploy (prod)

--- a/ui/app/dashboard/page.tsx
+++ b/ui/app/dashboard/page.tsx
@@ -158,7 +158,7 @@ export default function DashboardPage() {
       <div className="card">
         <h3>Dashboard</h3>
         <p className="subtle" style={{ marginTop: 8 }}>
-          Operational view of environments and runs, with KPI and cost surfaces that are still expanding in validation depth.
+          Operational view of environments and runs, plus KPI and cost signals for platform teams.
         </p>
       </div>
 
@@ -296,7 +296,7 @@ export default function DashboardPage() {
         </article>
         <article className="card">
           <h3>Workflow Integrations</h3>
-          <p className="subtle">Airflow and Dagster entry points (limited validation for production rollout).</p>
+          <p className="subtle">Airflow and Dagster entry points for orchestration-driven teams.</p>
           <Link href="/integrations" className="inline-link">Open integrations &rarr;</Link>
         </article>
       </div>

--- a/ui/app/getting-started/page.tsx
+++ b/ui/app/getting-started/page.tsx
@@ -106,9 +106,8 @@ export default function GettingStartedPage() {
           <div className="landing-section-badge">Public Pre-Access Guide</div>
           <h1 className="getting-started-title">Clear path from pre-access to authenticated onboarding</h1>
           <p className="getting-started-sub">
-            This page is public and explains where to start. End users sign in and follow authenticated onboarding.
-            Platform admins handle one-time
-            workspace setup and access mapping for the current batch-first launch scope.
+            This public page shows how teams get started. End users sign in and follow product onboarding, while platform
+            admins handle one-time workspace setup and access mapping.
           </p>
           <div className="landing-hero-actions">
             <Link href="/login?next=%2Fonboarding%2Faws" className="landing-btn landing-btn-primary">Sign in and continue</Link>
@@ -116,8 +115,7 @@ export default function GettingStartedPage() {
           </div>
           <div className="getting-started-callout">
             Public flow ends here. Product operations (Onboarding, Environments, Runs, Costs, Access) require sign-in.
-            Interactive endpoints, advanced template/security workflows, Lake Formation depth, and broader runtime parity
-            are not part of the current launch path yet.
+            Today’s launch focus is governed batch operations; interactive endpoints and broader runtime coverage are planned next.
           </div>
         </div>
 
@@ -156,7 +154,7 @@ export default function GettingStartedPage() {
 
           <div className="getting-started-section-title-row">
             <h2>Canonical onboarding sequence</h2>
-            <p>Follow these gates in order to reach a successful first run with evidence.</p>
+            <p>Follow these steps in order to reach your first successful run.</p>
           </div>
           <div className="getting-started-grid">
             {FLOW_STEPS.map((step) => (

--- a/ui/app/integrations/page.tsx
+++ b/ui/app/integrations/page.tsx
@@ -25,15 +25,15 @@ export default function IntegrationsPage() {
         <div className="eyebrow">WORKFLOW INTEGRATIONS</div>
         <h3>SparkPilot integration surfaces</h3>
         <p className="subtle" style={{ marginTop: 8 }}>
-          The web app, API, and CLI are the primary validated workflow surfaces today.
-          Airflow and Dagster packages exist in-source and are still in limited live validation.
+          The web app, API, and CLI are the primary operating surfaces today.
+          Airflow and Dagster packages are available in-source for team evaluation and rollout planning.
         </p>
       </div>
 
       <div className="card-grid">
         <article className="card">
           <h3>Airflow Provider</h3>
-          <p className="subtle">Hook/operator/sensor/trigger package exists. Production scheduler validation depth is still limited.</p>
+          <p className="subtle">Hook/operator/sensor/trigger package for integrating SparkPilot run operations into Airflow DAGs.</p>
           <div className="button-row">
             <a
               href="https://github.com/JoshMcQ/SparkPilot/tree/main/providers/airflow"
@@ -49,7 +49,7 @@ export default function IntegrationsPage() {
 
         <article className="card">
           <h3>Dagster Package</h3>
-          <p className="subtle">Resource + ops + assets package exists. End-to-end customer runtime validation is still limited.</p>
+          <p className="subtle">Resource + ops + assets package for Dagster-first teams standardizing run submission and monitoring.</p>
           <div className="button-row">
             <a
               href="https://github.com/JoshMcQ/SparkPilot/tree/main/providers/dagster"
@@ -73,8 +73,7 @@ export default function IntegrationsPage() {
           <li>Usage and KPI views provide operational evidence while broader cost reconciliation remains environment-dependent.</li>
         </ol>
         <p className="subtle" style={{ marginTop: 10 }}>
-          Coming soon for customer rollout claims: interactive endpoints, customer-facing template/security workflows,
-          and full multi-engine orchestration guarantees.
+          Planned next: interactive endpoint operations, richer template/security workflows, and broader multi-engine rollout.
         </p>
         <div className="button-row" style={{ marginTop: 12 }}>
           <Link href="/access" className="button button-secondary">Access</Link>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -20,31 +20,31 @@ const LIVE_NOW = [
     icon: <IconCheck />,
     title: "Batch run lifecycle",
     description:
-      "End-to-end staged flow is live: sign in, submit batch runs, monitor state, open logs, and view diagnostics.",
+      "Sign in, submit governed batch runs, track status, inspect logs, and review diagnostics in one workflow.",
   },
   {
     icon: <IconCompass />,
     title: "BYOC-Lite onboarding",
     description:
-      "Admins can connect an existing EKS cluster and reach a ready EMR on EKS environment through guided onboarding.",
+      "Admins can connect an existing EKS cluster and bring up an EMR on EKS environment through guided onboarding.",
   },
   {
     icon: <IconLock />,
     title: "OIDC auth and scoped access",
     description:
-      "OIDC sign-in and role checks are active in the API and UI for admin/operator/user access boundaries.",
+      "OIDC sign-in and role-aware access controls are available across the API and product UI.",
   },
   {
     icon: <IconActivity />,
     title: "Run operations workspace",
     description:
-      "Runs page supports job definition creation, run submission, queue/status visibility, logs, and diagnostics.",
+      "The Runs workspace supports job definition setup, run submission, status tracking, logs, and diagnostics.",
   },
   {
     icon: <IconDollar />,
     title: "Usage and KPI visibility",
     description:
-      "Usage records and KPI endpoints are wired and visible for staged operational evidence.",
+      "Usage records and KPI views are available for day-to-day operational visibility.",
   },
 ];
 
@@ -53,25 +53,25 @@ const LIMITED_VALIDATION = [
     icon: <IconGitBranch />,
     title: "Policy engine",
     description:
-      "Policy CRUD and preflight evaluation paths are implemented, but enterprise-hardening and broader runtime proof are still in progress.",
+      "Policy CRUD and preflight enforcement are available today, with broader enterprise packaging in active delivery.",
   },
   {
     icon: <IconTrendingDown />,
     title: "CUR reconciliation and budget workflows",
     description:
-      "Cost and budget surfaces are implemented, but customer-by-customer CUR data wiring and validation depth vary.",
+      "Cost and budget workflows are in place, with customer-specific CUR setup depending on each AWS environment.",
   },
   {
     icon: <IconLayers />,
     title: "Lake Formation and queue signals",
     description:
-      "Lake Formation preflight logic and queue utilization APIs exist, but customer-facing rollout proof is still limited by environment-specific setup.",
+      "Lake Formation checks and queue utilization signals are implemented and being expanded into broader operator workflows.",
   },
   {
     icon: <IconCloud />,
     title: "Orchestration packages",
     description:
-      "Airflow and Dagster providers are implemented in-source, with narrower live validation for customer production rollout.",
+      "Airflow and Dagster packages are available in-source and are being expanded for wider production onboarding.",
   },
 ];
 
@@ -80,19 +80,19 @@ const COMING_SOON = [
     icon: <IconAlertTriangle />,
     title: "Interactive endpoints",
     description:
-      "Endpoint APIs exist, but interactive governance controls and operational maturity are not yet launch-ready.",
+      "Interactive endpoint management with enterprise governance controls.",
   },
   {
     icon: <IconCloud />,
     title: "Multi-engine runtime parity",
     description:
-      "Serverless, EMR on EC2, and Databricks code paths exist in backend routing but are not yet proven launch workflows.",
+      "Expanded runtime coverage across EMR Serverless, EMR on EC2, and Databricks.",
   },
   {
     icon: <IconAlertTriangle />,
     title: "Template and security workflows",
     description:
-      "Job template, security configuration, and YuniKorn queue controls need stronger customer-facing UX and rollout evidence before launch claims.",
+      "Broader template, security configuration, and YuniKorn operator workflows in the product UI.",
   },
 ];
 
@@ -117,7 +117,7 @@ const NOT_LAUNCH_SCOPE = [
   "Lake Formation and YuniKorn customer-facing operations",
   "Full multi-engine customer parity",
   "Enterprise compliance packaging claims",
-  "Broad orchestration-runtime guarantees beyond staged proof",
+  "Broad orchestration guarantees across every runtime",
 ];
 
 function CapabilityColumn({
@@ -154,41 +154,41 @@ export default function LandingPage() {
       <LandingNav />
 
       <section className="landing-hero" id="hero">
-        <div className="landing-hero-badge">AWS-first batch governance control plane</div>
+        <div className="landing-hero-badge">AWS-first Spark control plane</div>
         <h2 className="landing-hero-title">
-          SparkPilot launch scope is now <br />
-          <span className="landing-hero-accent">explicit and evidence-backed</span>
+          Governed Spark operations <br />
+          <span className="landing-hero-accent">for enterprise AWS teams</span>
         </h2>
         <p className="landing-hero-sub">
-          SparkPilot is focused on one honest story for launch: governed batch Spark operations in your AWS account.
-          We separate what is live now from what is beta and what is still coming soon.
+          SparkPilot helps platform teams connect their AWS environment, run governed batch workloads, and operate with
+          clear diagnostics and cost visibility.
         </p>
         <div className="landing-hero-actions">
           <Link href="/getting-started" className="landing-btn landing-btn-primary">
-            Start with staged flow
+            Start evaluation
           </Link>
           <Link href="/pricing" className="landing-btn landing-btn-secondary">
-            View scope and plans
+            View plans
           </Link>
         </div>
         <p className="landing-hero-note">
-          BYOC-Lite is the current validated path. Full BYOC and broader engine coverage are limited validation.
+          Current release focus: batch-first on EMR on EKS. Interactive workflows and broader runtime coverage are planned next.
         </p>
       </section>
 
       <div id="features" />
       <section className="landing-section" id="truth-map">
         <div className="landing-section-header">
-          <div className="landing-section-badge">Product Truth Map</div>
-          <h2 className="landing-section-title">Live now, limited validation, and coming soon</h2>
+          <div className="landing-section-badge">Product Overview</div>
+          <h2 className="landing-section-title">Available today, current focus, and planned next</h2>
           <p className="landing-section-sub">
-            Capability labels are tied to current staging evidence and implementation depth.
+            A clear view of what teams can use now, what is expanding next, and what is on the roadmap.
           </p>
         </div>
         <div className="landing-engines-grid">
-          <CapabilityColumn title="Live now" subtitle="Validated in staged customer workflow." rows={LIVE_NOW} />
-          <CapabilityColumn title="Limited validation / beta" subtitle="Implemented with narrower live proof." rows={LIMITED_VALIDATION} />
-          <CapabilityColumn title="Coming soon" subtitle="Do not treat as launch commitments yet." rows={COMING_SOON} />
+          <CapabilityColumn title="Available today" subtitle="Ready for pilots and technical evaluations." rows={LIVE_NOW} />
+          <CapabilityColumn title="Current focus" subtitle="In active delivery for broader enterprise rollout." rows={LIMITED_VALIDATION} />
+          <CapabilityColumn title="Planned next" subtitle="On the roadmap for future releases." rows={COMING_SOON} />
         </div>
       </section>
 
@@ -258,10 +258,9 @@ export default function LandingPage() {
       </section>
 
       <section className="landing-cta">
-        <h2>Need a realistic pilot path?</h2>
+        <h2>Need a practical pilot plan?</h2>
         <p>
-          Start with the staged batch-first workflow, validate against your own BYOC setup, then expand capability
-          claims only after live evidence exists.
+          Start with a batch-first rollout in your AWS account, then expand scope as your production readiness grows.
         </p>
         <div className="landing-hero-actions">
           <Link href="/getting-started" className="landing-btn landing-btn-primary">

--- a/ui/app/policies/page.tsx
+++ b/ui/app/policies/page.tsx
@@ -322,7 +322,7 @@ const POLICY_WORKFLOW = [
   "Hard-block policies reject the submission with a clear error and the policy name.",
   "Soft-warn policies allow the submission but record the warning in the run audit trail.",
   "Policies apply to all scopes below them: a global policy applies everywhere; a tenant policy applies to all environments in that tenant.",
-  "Policy behavior is active in environments where policy checks are enabled. Validate policy configs in staging before broad rollout.",
+  "Policy behavior is active in environments where policy checks are enabled. Validate policy configs in non-production before broad rollout.",
 ];
 
 export default function PoliciesPage() {
@@ -367,7 +367,7 @@ export default function PoliciesPage() {
         <div className="subtle">
           Submission guardrails evaluated at preflight before every run. Hard-block policies reject
           submissions; soft-warn policies allow with a warning recorded in the audit trail. This
-          surface is in limited-validation status for staged rollout.
+          surface is designed for operator-driven rollout.
         </div>
       </div>
 

--- a/ui/app/pricing/page.tsx
+++ b/ui/app/pricing/page.tsx
@@ -21,9 +21,9 @@ const TIERS = [
   },
   {
     name: "Staging Pilot",
-    price: "Current focus",
+    price: "Pilot-ready",
     period: "",
-    description: "Validated, batch-first staged workflow for real customer-style trials.",
+    description: "Batch-first enterprise workflow for pilots, evaluations, and internal rollout.",
     cta: "Start staging flow",
     ctaHref: "/getting-started",
     ctaStyle: "landing-btn-primary",
@@ -33,15 +33,15 @@ const TIERS = [
       "BYOC-Lite environment connection",
       "Batch run submit, monitor, logs, diagnostics",
       "Usage and KPI visibility",
-      "Policy and governance basics (limited validation)",
-      "Advanced runtime features clearly labeled as beta or coming soon",
+      "Policy and governance foundation",
+      "Clear roadmap for advanced runtime capabilities",
     ],
   },
   {
     name: "Enterprise Expansion",
     price: "Coming soon",
     period: "",
-    description: "Broader multi-engine and enterprise packaging after additional live validation.",
+    description: "Expanded runtime coverage and enterprise packaging as the platform roadmap advances.",
     cta: "Talk to us",
     ctaHref: "/contact",
     ctaStyle: "landing-btn-secondary",
@@ -53,7 +53,7 @@ const TIERS = [
       "Lake Formation and YuniKorn rollout depth",
       "Broader runtime parity",
       "Expanded compliance and support packaging",
-      "Only announced after evidence-backed readiness",
+      "Co-developed with pilot and customer rollout priorities",
     ],
   },
 ];
@@ -61,19 +61,19 @@ const TIERS = [
 const FAQ = [
   {
     q: "Is SparkPilot fully production-wide today?",
-    a: "Not yet. The current honest scope is a staged, batch-first workflow with clearly marked beta and coming-soon areas.",
+    a: "Today’s launch scope is batch-first on EMR on EKS with BYOC-Lite onboarding, governed runs, and operator workflows.",
   },
   {
     q: "What is the best path to evaluate right now?",
-    a: "Use the staging flow end-to-end: sign in, onboard, connect BYOC-Lite environment, submit a run, and verify logs/diagnostics/usage.",
+    a: "Run the full pilot path: sign in, connect BYOC-Lite, submit a run, and review logs, diagnostics, and usage.",
   },
   {
     q: "Are all backend features customer-ready?",
-    a: "No. Some backend capabilities exist without full customer-surface or live validation yet; those are marked as beta or coming soon.",
+    a: "No. Some backend capabilities are still maturing into full customer workflows and are listed under Planned next.",
   },
   {
-    q: "How are advanced features currently classified?",
-    a: "Interactive endpoints, template/security workflows, Lake Formation depth, YuniKorn controls, and broader orchestration rollout are currently beta or coming soon unless explicitly proven.",
+    q: "What is planned next?",
+    a: "Interactive endpoints, richer template/security workflows, Lake Formation depth, YuniKorn controls, and broader orchestration rollout.",
   },
   {
     q: "Does SparkPilot run in our AWS account?",
@@ -89,12 +89,11 @@ export default function PricingPage() {
       <section className="landing-hero" style={{ paddingBottom: "clamp(28px, 4vw, 48px)" }}>
         <div className="landing-hero-badge">Plans and Scope</div>
         <h2 className="landing-hero-title">
-          Honest packaging for the <br />
-          <span className="landing-hero-accent">current product stage</span>
+          Packaging for pilot rollout <br />
+          <span className="landing-hero-accent">and enterprise expansion</span>
         </h2>
         <p className="landing-hero-sub">
-          This page reflects current reality: what is usable now, what is in limited validation, and what is not yet
-          a launch commitment.
+          Start with the pilot-ready path today, then expand into broader enterprise capabilities as your rollout grows.
         </p>
       </section>
 
@@ -135,7 +134,7 @@ export default function PricingPage() {
       <section className="landing-section">
         <div className="landing-section-header">
           <div className="landing-section-badge">FAQ</div>
-          <h2 className="landing-section-title">Scope clarity</h2>
+          <h2 className="landing-section-title">Plan clarity</h2>
         </div>
         <div className="faq-list">
           {FAQ.map((item) => (
@@ -148,8 +147,8 @@ export default function PricingPage() {
       </section>
 
       <section className="landing-cta">
-        <h2>Need an evidence-backed pilot path?</h2>
-        <p>Start with the staged workflow and expand scope only after live validation in your environment.</p>
+        <h2>Need a rollout plan for your team?</h2>
+        <p>Start with the pilot workflow, then expand scope in line with your production timeline.</p>
         <div className="landing-hero-actions">
           <Link href="/getting-started" className="landing-btn landing-btn-primary">Open getting started</Link>
           <Link href="/contact" className="landing-btn landing-btn-secondary">Talk to us</Link>

--- a/ui/app/why-not-diy/page.tsx
+++ b/ui/app/why-not-diy/page.tsx
@@ -63,36 +63,36 @@ const COSTS = [
 
 const WHAT_SP_SHIPS = [
   {
-    title: "Live now: Preflight checks",
+    title: "Available today: Preflight checks",
     body: "20+ IAM, OIDC, quota, policy, release, and spot readiness checks run before every dispatch - not after the job fails.",
   },
   {
-    title: "Live now: BYOC-Lite onboarding",
+    title: "Available today: BYOC-Lite onboarding",
     body: "Automated virtual cluster provisioning, trust policy management, and OIDC provider association in your account.",
   },
   {
-    title: "Limited validation: Policy engine",
-    body: "Policy CRUD and enforcement paths are implemented, with broader enterprise hardening and validation still in progress.",
+    title: "Current focus: Policy engine",
+    body: "Policy CRUD and enforcement are available now, with expanded enterprise policy packs in active delivery.",
   },
   {
-    title: "Limited validation: Cost reconciliation",
-    body: "Per-run cost tagging and CUR reconciliation paths exist, but proof depth is still environment-dependent.",
+    title: "Current focus: Cost reconciliation",
+    body: "Per-run cost tagging and CUR reconciliation are available, with depth tied to each customer's CUR setup.",
   },
   {
-    title: "Limited validation: EMR release lifecycle",
-    body: "Release lifecycle checks and warnings exist, but broad production validation across customer release matrices is still progressing.",
+    title: "Current focus: EMR release lifecycle",
+    body: "Release lifecycle checks and warnings are available and expanding across broader rollout scenarios.",
   },
   {
-    title: "Limited validation: Team budgets",
-    body: "Budget guardrail logic is implemented with warning and block behavior, with limited live validation so far.",
+    title: "Current focus: Team budgets",
+    body: "Budget guardrails support warning and block behavior for operator-controlled rollout.",
   },
   {
-    title: "Live now: Structured diagnostics",
+    title: "Available today: Structured diagnostics",
     body: "CloudWatch log analysis with pattern matching for spot interruptions, OOM, executor failures, and configuration errors.",
   },
   {
-    title: "Coming soon: YuniKorn scheduling controls",
-    body: "Queue utilization hints exist, while fully proven multi-tenant YuniKorn workflow guarantees remain in progress.",
+    title: "Planned next: YuniKorn scheduling controls",
+    body: "Queue utilization hints are in place, with fuller multi-tenant queue controls planned next.",
   },
 ];
 
@@ -108,9 +108,8 @@ export default function WhyNotDIYPage() {
             &ldquo;We can build this ourselves.&rdquo;
           </h1>
           <p className="objection-hero-sub">
-            You can. Platform teams have been doing it for years. Here is an honest accounting
-            of what that actually costs - and what you are giving up every month you are doing
-            it by hand.
+            You can. Platform teams do it every day. This is a practical breakdown of what it costs to build
+            and operate in-house - and what you can accelerate with SparkPilot.
           </p>
         </section>
 
@@ -118,8 +117,8 @@ export default function WhyNotDIYPage() {
         <section className="objection-section">
           <h2 className="objection-section-title">The real cost of DIY EMR on EKS</h2>
           <p className="objection-section-sub">
-            These estimates are based on work we observed while building SparkPilot.
-            Your numbers will vary - but the categories won't.
+            These are directional planning estimates based on common platform delivery patterns.
+            Your numbers will vary, but the workload categories are consistent across teams.
           </p>
           <div className="objection-cost-grid">
             {COSTS.map((c) => (
@@ -145,8 +144,7 @@ export default function WhyNotDIYPage() {
         <section className="objection-section objection-section-alt">
           <h2 className="objection-section-title">What SparkPilot ships today</h2>
           <p className="objection-section-sub">
-            Not roadmap placeholders. These are implemented product surfaces, with validation
-            depth varying by feature and runtime.
+            Core product capabilities for pilot rollout, plus the next set of expansion areas.
           </p>
           <div className="objection-ships-grid">
             {WHAT_SP_SHIPS.map((item) => (

--- a/ui/app/why-not-serverless/page.tsx
+++ b/ui/app/why-not-serverless/page.tsx
@@ -33,7 +33,7 @@ const TRADEOFFS = [
     description:
       "YuniKorn provides queue-based fair scheduling, guaranteed vCPU allocations per team, and preemption policies. None of these exist in Serverless - every application competes for capacity without SLA guarantees.",
     sparkpilot:
-      "SparkPilot supports YuniKorn queue fields and preflight queue-capacity checks, but customer rollout validation is still limited.",
+      "SparkPilot supports YuniKorn queue fields and preflight queue-capacity checks, with broader queue operations planned next.",
   },
   {
     title: "No cost allocation per team",
@@ -41,7 +41,7 @@ const TRADEOFFS = [
     description:
       "Serverless bills by application-level resource usage, but does not give you per-team or per-run cost attribution unless you build it yourself using resource tags and a CUR pipeline.",
     sparkpilot:
-      "SparkPilot tracks per-run usage and attribution fields, with deeper cost reconciliation depending on customer CUR setup and validation depth.",
+      "SparkPilot tracks per-run usage and attribution fields, with deeper cost reconciliation based on customer CUR setup.",
   },
   {
     title: "No BYOC model",
@@ -57,7 +57,7 @@ const TRADEOFFS = [
     description:
       "Serverless will accept and start any job you submit. Resource limits, release label policies, and team budget caps are not enforced at submission time. You discover overages in the bill.",
     sparkpilot:
-      "SparkPilot policy checks run at preflight, with policy maturity currently in limited-validation status.",
+      "SparkPilot policy checks run at preflight and support operator-controlled rollout.",
   },
   {
     title: "Limited Spark configuration surface",
@@ -125,8 +125,8 @@ export default function WhyNotServerlessPage() {
             &ldquo;Why not just use EMR Serverless?&rdquo;
           </h1>
           <p className="objection-hero-sub">
-            EMR Serverless is a legitimate option for some workloads. Here is an honest breakdown
-            of the tradeoffs - so you can make the right call for your team's actual requirements.
+            EMR Serverless is a strong choice for some workloads. This page outlines the tradeoffs so platform teams
+            can choose the right operating model.
           </p>
         </section>
 
@@ -164,8 +164,7 @@ export default function WhyNotServerlessPage() {
         <section className="objection-section objection-section-alt">
           <h2 className="objection-section-title">Tradeoff deep-dive</h2>
           <p className="objection-section-sub">
-            These are real constraints - not marketing FUD. Each one matters in specific
-            production scenarios.
+            These constraints matter in real production scenarios and should be evaluated against your workload profile.
           </p>
           <div className="objection-tradeoff-list">
             {TRADEOFFS.map((t) => (
@@ -206,9 +205,8 @@ export default function WhyNotServerlessPage() {
         <section className="objection-section objection-section-highlight">
           <h2 className="objection-section-title">EMR Serverless path status</h2>
           <p>
-            SparkPilot includes backend dispatch code for EMR Serverless, but the current launch scope is
-            batch-first on EMR on EKS. Treat Serverless as coming soon until complete end-to-end validation
-            and support workflows are in place.
+            SparkPilot includes backend dispatch code for EMR Serverless. The current product focus is batch-first on
+            EMR on EKS, with broader multi-engine operations planned next.
           </p>
           <p>
             If your immediate priority is low-ops ad-hoc execution, EMR Serverless may still be the better short-term

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1,4 +1,5 @@
-const API_PREFIX = "/api/sparkpilot";
+const RAW_API_PREFIX = (process.env.NEXT_PUBLIC_SPARKPILOT_API_PREFIX ?? "/api/sparkpilot").trim();
+const API_PREFIX = RAW_API_PREFIX === "/" ? "" : RAW_API_PREFIX.replace(/\/+$/, "");
 export const USER_ACCESS_TOKEN_STORAGE_KEY = "sparkpilot.userAccessToken";
 export const USER_ACCESS_TOKEN_CHANGED_EVENT = "sparkpilot:user-access-token-changed";
 /**


### PR DESCRIPTION
## Summary
- Rewrites public-facing product copy from internal audit language to concise enterprise product voice
- Keeps truthful narrowed scope using cleaner framing (`Available today`, `Current focus`, `Planned next`)
- Adds configurable `NEXT_PUBLIC_SPARKPILOT_API_PREFIX` so staging can bypass the failing authenticated `/api/sparkpilot/*` proxy path
- Wires env-specific API prefix build args in CI/CD (`DEV|STAGING|PROD_SPARKPILOT_API_PREFIX`)

## Why this matters
- Public site now reads like enterprise software positioning, not an internal repo review
- Staging authenticated app flow currently fails through proxy path (`/api/sparkpilot/*` 502 via Cloudflare host error)
- Direct `/v1/*` path is healthy in staging; this change allows staging UI to use that path safely

## Validation
- `npm --prefix ui run build` passes locally
- Staging env variable set:
  - `STAGING_SPARKPILOT_API_PREFIX=/`
  - `STAGING_DEPLOY_ENABLED=true` (temporary for deploy verification)

## Post-merge follow-up
- Verify staging login -> onboarding -> environments/runs API calls succeed
- Reset `STAGING_DEPLOY_ENABLED=false` after verification to keep non-prod dormant by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined messaging across product pages to clarify current feature availability, validation status, and planned next-phase enhancements, including updates to dashboard, onboarding, integrations, pricing, and comparison pages.

* **Chores**
  * Made API endpoint prefix configurable via environment variable with sensible defaults to support flexible deployment configurations across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->